### PR TITLE
feat: add webpack 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  Get insights into your <strong>webpack v4</strong> bundles as early as possible.
+  Get insights into your <strong>webpack <em>(v4 or v5)</em></strong> bundles as early as possible.
 </p>
 
 Features:
@@ -59,7 +59,7 @@ Which would result in a similar output to the below
 
 ### Significant changes
 
-| File                       |             Size            |         Gzip size          |         Brotli size        |
+| File                       |            Size             |         Gzip size          |        Brotli size         |
 | :------------------------- | :-------------------------: | :------------------------: | :------------------------: |
 | vendors~tocInformation.mjs | 30.28KB (+7.39KB / +32.31%) | 9.34KB (+2.03KB / +27.81%) | 8.06KB (+1.73KB / +27.25%) |
 | vendors~tocInformation.js  | 32.19KB (+7.68KB / +31.36%) | 9.75KB (+2.09KB / +27.34%) | 8.43KB (+1.78KB / +26.69%) |
@@ -67,14 +67,14 @@ Which would result in a similar output to the below
 
 ### Minor changes
 
-| File                                |            Size           |         Gzip size         |        Brotli size        |
-| :---------------------------------- | :-----------------------: | :-----------------------: | :-----------------------: |
-| trainTimesPageV2.mjs                | 565.71KB (+347B / +0.06%) |  150.4KB (-431B / -0.28%) |  118.66KB (+69B / +0.06%) |
-| trainTimesPageV2.js                 | 623.43KB (+370B / +0.06%) |  162.1KB (-22B / -0.01%)  |  124.97KB (+10B / +0.01%) |
-| intl.js                             |            80B            |             -             |             -             |
-| intl.mjs                            |            80B            |             -             |             -             |
-| locale-data-fr.js                   |          11.08KB          |           1.8KB           |           1.54KB          |
-| locale-data-fr.mjs                  |          10.71KB          |           1.61KB          |           1.38KB          |
+| File                 |           Size            |        Gzip size         |       Brotli size        |
+| :------------------- | :-----------------------: | :----------------------: | :----------------------: |
+| trainTimesPageV2.mjs | 565.71KB (+347B / +0.06%) | 150.4KB (-431B / -0.28%) | 118.66KB (+69B / +0.06%) |
+| trainTimesPageV2.js  | 623.43KB (+370B / +0.06%) | 162.1KB (-22B / -0.01%)  | 124.97KB (+10B / +0.01%) |
+| intl.js              |            80B            |            -             |            -             |
+| intl.mjs             |            80B            |            -             |            -             |
+| locale-data-fr.js    |          11.08KB          |          1.8KB           |          1.54KB          |
+| locale-data-fr.mjs   |          10.71KB          |          1.61KB          |          1.38KB          |
 
 <truncated as the table gets quite long>
 

--- a/docs/gather-webpack-stats.md
+++ b/docs/gather-webpack-stats.md
@@ -52,7 +52,7 @@ If you do desire more granular control, please ensure to set the following `stat
 
 [Trivago's `parallel-webpack`](https://github.com/trivago/parallel-webpack) is a great tool to help speed up multiple webpack compilations.
 
-When using `--profile --json` with `parallel-webpack`, the output isn't exactly aligned with what `webpack` itself would produced, but we have catered for that with the [`extractStats.ts` helper](../src/helpers/extractStats.ts) which is applied via the data sources logic.
+When using `--profile --json` with `parallel-webpack`, the output isn't exactly aligned with what `webpack` itself would produced, but we have catered for that with the [`normalizeStats.ts` helper](../src/helpers/normalizeStats.ts) which is applied via the data sources logic.
 
 However, when used with a Stats Plugin such as `webpack-stats-plugin`, there is a good chance the only output for it will be the compilation which finished last. This is because each plugin is executed at the end of the compile step.
 

--- a/docs/gather-webpack-stats.md
+++ b/docs/gather-webpack-stats.md
@@ -52,7 +52,7 @@ If you do desire more granular control, please ensure to set the following `stat
 
 [Trivago's `parallel-webpack`](https://github.com/trivago/parallel-webpack) is a great tool to help speed up multiple webpack compilations.
 
-When using `--profile --json` with `parallel-webpack`, the output isn't exactly aligned with what `webpack` itself would produced, but we have catered for that with the [`extractStats.ts` helper](../src/helpers/extractStats.ts).
+When using `--profile --json` with `parallel-webpack`, the output isn't exactly aligned with what `webpack` itself would produced, but we have catered for that with the [`extractStats.ts` helper](../src/helpers/extractStats.ts) which is applied via the data sources logic.
 
 However, when used with a Stats Plugin such as `webpack-stats-plugin`, there is a good chance the only output for it will be the compilation which finished last. This is because each plugin is executed at the end of the compile step.
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ts-jest": "^26.4.3",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.5",
-    "webpack": "^5.21.0",
+    "webpack": "^5.36.2",
     "webpack4": "npm:webpack@^4.44.2"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ts-jest": "^26.4.3",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.5",
-    "webpack": "^5.9.0",
+    "webpack": "^5.21.0",
     "webpack4": "npm:webpack@^4.44.2"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/jest": "^26.0.15",
     "@types/lodash": "^4.14.165",
     "@types/markdown-table": "^2.0.0",
-    "@types/webpack": "^4.41.24",
+    "@types/webpack4": "npm:@types/webpack@^4.41.24",
     "commitizen": "^4.2.2",
     "cross-env": "^7.0.2",
     "cz-customizable": "^6.3.0",
@@ -82,7 +82,7 @@
     "ts-jest": "^26.4.3",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.5",
-    "webpack": "^4.44.2"
+    "webpack4": "npm:webpack@^4.44.2"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "ts-jest": "^26.4.3",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.5",
+    "webpack": "^5.9.0",
     "webpack4": "npm:webpack@^4.44.2"
   },
   "config": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import * as cliDataSources from './dataSources/cliIndex';
 import { ExecOptions } from './CliProgram';
 import config from './config';
 import plugins from './plugins';
+import normalizeStats from './helpers/normalizeStats';
 
 const packageJson = JSON.parse(
   readFileSync(path.normalize(path.join(__dirname, '../package.json')), 'utf-8')
@@ -35,7 +36,10 @@ async function exec({ dataSource, baseSha, headSha }: ExecOptions) {
     headSha
   );
 
-  const pluginInstances = await plugins(userConfig, baseCompilationStats, headCompilationStats);
+  const normalizedBaseStats = normalizeStats(baseCompilationStats);
+  const normalizedHeadStats = normalizeStats(headCompilationStats);
+
+  const pluginInstances = await plugins(userConfig, normalizedBaseStats, normalizedHeadStats);
   const errors = (await Promise.all(pluginInstances.map((plugin) => plugin.errorMessages())))
     .flat()
     .filter((line) => !!line && line.length);

--- a/src/danger.ts
+++ b/src/danger.ts
@@ -7,6 +7,7 @@ import 'core-js';
 import BaseDataSource, { DataSourceBranchType } from './dataSources/BaseDataSource';
 import plugins from './plugins';
 import config from './config';
+import normalizeStats from './helpers/normalizeStats';
 
 // ref: https://danger.systems/js/usage/extending-danger.html#writing-your-plugin
 // copied from: https://github.com/danger/generator-danger-plugin/blob/master/src/app/templates/ts/src/index.ts#L4-L10
@@ -35,11 +36,10 @@ const danger = ({ dataSource, baseSha, headSha }: DangerExec): void => {
           headSha
         );
 
-        const pluginInstances = await plugins(
-          userConfig,
-          baseCompilationStats,
-          headCompilationStats
-        );
+        const normalizedBaseStats = normalizeStats(baseCompilationStats);
+        const normalizedHeadStats = normalizeStats(headCompilationStats);
+
+        const pluginInstances = await plugins(userConfig, normalizedBaseStats, normalizedHeadStats);
 
         const errors = (
           await Promise.all(pluginInstances.map((plugin) => plugin.errorMessages()))

--- a/src/dataSources/BaseDataSource.ts
+++ b/src/dataSources/BaseDataSource.ts
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import { Stats } from '../helpers/constants';
 import extractStats, { ExtractedStats } from '../helpers/extractStats';
+import { Stats } from '../types';
 
 export enum DataSourceBranchType {
   base = 'base',

--- a/src/dataSources/BaseDataSource.ts
+++ b/src/dataSources/BaseDataSource.ts
@@ -3,8 +3,7 @@
  * See LICENSE.md in the project root for license information.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
+import { Stats, Stats4 } from '../helpers/constants';
 import extractStats from '../helpers/extractStats';
 
 export enum DataSourceBranchType {
@@ -13,10 +12,7 @@ export enum DataSourceBranchType {
 }
 
 export interface DataSource {
-  getCompilationStats(
-    branchType: DataSourceBranchType,
-    sha: string
-  ): Promise<webpack4.Stats.ToJsonOutput>;
+  getCompilationStats(branchType: DataSourceBranchType, sha: string): Promise<Stats4>;
 }
 
 /* eslint-disable class-methods-use-this, @typescript-eslint/no-unused-vars */
@@ -27,17 +23,14 @@ export default class BaseDataSource implements DataSource {
     }
   }
 
-  getCompilationStats(
-    _branchType: DataSourceBranchType,
-    _sha: string
-  ): Promise<webpack4.Stats.ToJsonOutput> {
+  getCompilationStats(_branchType: DataSourceBranchType, _sha: string): Promise<Stats4> {
     throw new Error(
       'BaseDataSource cannot be used, please use one of the other data sources or extend this class'
     );
   }
 
-  validateCompilationStats(compilationStats: webpack4.Stats.ToJsonOutput): void {
-    const containsRequiredProps = extractStats(compilationStats).some((stats) => {
+  validateCompilationStats(compilationStats: Stats4): void {
+    const containsRequiredProps = extractStats(compilationStats).stats.some((stats: Stats) => {
       const { assets, modules } = stats;
       return assets?.length && modules?.length;
     });

--- a/src/dataSources/BaseDataSource.ts
+++ b/src/dataSources/BaseDataSource.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import extractStats, { ExtractedStats } from '../helpers/extractStats';
+import normalizeStats from '../helpers/normalizeStats';
 import { Stats } from '../types';
 
 export enum DataSourceBranchType {
@@ -12,7 +12,7 @@ export enum DataSourceBranchType {
 }
 
 export interface DataSource {
-  getCompilationStats(branchType: DataSourceBranchType, sha: string): Promise<ExtractedStats>;
+  getCompilationStats(branchType: DataSourceBranchType, sha: string): Promise<Stats>;
 }
 
 /* eslint-disable class-methods-use-this, @typescript-eslint/no-unused-vars */
@@ -23,14 +23,14 @@ export default class BaseDataSource implements DataSource {
     }
   }
 
-  getCompilationStats(_branchType: DataSourceBranchType, _sha: string): Promise<ExtractedStats> {
+  getCompilationStats(_branchType: DataSourceBranchType, _sha: string): Promise<Stats> {
     throw new Error(
       'BaseDataSource cannot be used, please use one of the other data sources or extend this class'
     );
   }
 
   validateCompilationStats(compilationStats: Stats): void {
-    const containsRequiredProps = extractStats(compilationStats).stats.some((stats: Stats) => {
+    const containsRequiredProps = normalizeStats(compilationStats).stats.some((stats: Stats) => {
       const { assets, modules } = stats;
       return assets?.length && modules?.length;
     });

--- a/src/dataSources/BaseDataSource.ts
+++ b/src/dataSources/BaseDataSource.ts
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import { Stats, Stats4 } from '../helpers/constants';
-import extractStats from '../helpers/extractStats';
+import { Stats } from '../helpers/constants';
+import extractStats, { ExtractedStats } from '../helpers/extractStats';
 
 export enum DataSourceBranchType {
   base = 'base',
@@ -12,7 +12,7 @@ export enum DataSourceBranchType {
 }
 
 export interface DataSource {
-  getCompilationStats(branchType: DataSourceBranchType, sha: string): Promise<Stats4>;
+  getCompilationStats(branchType: DataSourceBranchType, sha: string): Promise<ExtractedStats>;
 }
 
 /* eslint-disable class-methods-use-this, @typescript-eslint/no-unused-vars */
@@ -23,13 +23,13 @@ export default class BaseDataSource implements DataSource {
     }
   }
 
-  getCompilationStats(_branchType: DataSourceBranchType, _sha: string): Promise<Stats4> {
+  getCompilationStats(_branchType: DataSourceBranchType, _sha: string): Promise<ExtractedStats> {
     throw new Error(
       'BaseDataSource cannot be used, please use one of the other data sources or extend this class'
     );
   }
 
-  validateCompilationStats(compilationStats: Stats4): void {
+  validateCompilationStats(compilationStats: Stats): void {
     const containsRequiredProps = extractStats(compilationStats).stats.some((stats: Stats) => {
       const { assets, modules } = stats;
       return assets?.length && modules?.length;

--- a/src/dataSources/BaseDataSource.ts
+++ b/src/dataSources/BaseDataSource.ts
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import extractStats from '../helpers/extractStats';
 
 export enum DataSourceBranchType {
@@ -16,7 +16,7 @@ export interface DataSource {
   getCompilationStats(
     branchType: DataSourceBranchType,
     sha: string
-  ): Promise<webpack.Stats.ToJsonOutput>;
+  ): Promise<webpack4.Stats.ToJsonOutput>;
 }
 
 /* eslint-disable class-methods-use-this, @typescript-eslint/no-unused-vars */
@@ -30,13 +30,13 @@ export default class BaseDataSource implements DataSource {
   getCompilationStats(
     _branchType: DataSourceBranchType,
     _sha: string
-  ): Promise<webpack.Stats.ToJsonOutput> {
+  ): Promise<webpack4.Stats.ToJsonOutput> {
     throw new Error(
       'BaseDataSource cannot be used, please use one of the other data sources or extend this class'
     );
   }
 
-  validateCompilationStats(compilationStats: webpack.Stats.ToJsonOutput): void {
+  validateCompilationStats(compilationStats: webpack4.Stats.ToJsonOutput): void {
     const containsRequiredProps = extractStats(compilationStats).some((stats) => {
       const { assets, modules } = stats;
       return assets?.length && modules?.length;

--- a/src/dataSources/LocalFile/index.test.ts
+++ b/src/dataSources/LocalFile/index.test.ts
@@ -9,8 +9,8 @@ import LocalFileDataSource, { LocalFileDataSourceConfiguration } from '.';
 
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
-import { Stats } from '../../helpers/constants';
 import { ExtractedStats } from '../../helpers/extractStats';
+import { Stats } from '../../types';
 import { DataSourceBranchType } from '../BaseDataSource';
 
 jest.mock('fs');

--- a/src/dataSources/LocalFile/index.test.ts
+++ b/src/dataSources/LocalFile/index.test.ts
@@ -9,7 +9,8 @@ import LocalFileDataSource, { LocalFileDataSourceConfiguration } from '.';
 
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
-import { Stats4 } from '../../helpers/constants';
+import { Stats } from '../../helpers/constants';
+import { ExtractedStats } from '../../helpers/extractStats';
 import { DataSourceBranchType } from '../BaseDataSource';
 
 jest.mock('fs');
@@ -55,8 +56,8 @@ describe('LocalFileDataSource', () => {
   });
 
   describe('getCompilationStats()', () => {
-    const baseStats = (baseCompilationStats as unknown) as Stats4;
-    const headStats = (headCompilationStats as unknown) as Stats4;
+    const baseStats = (baseCompilationStats as unknown) as Stats;
+    const headStats = (headCompilationStats as unknown) as Stats;
 
     describe('happy path', () => {
       beforeEach(() => {
@@ -76,15 +77,19 @@ describe('LocalFileDataSource', () => {
       });
 
       it('returns the base compilation stats when specified', () => {
-        return expect(dataSource.getCompilationStats(DataSourceBranchType.base)).resolves.toEqual(
-          baseStats
-        );
+        return expect(
+          dataSource.getCompilationStats(DataSourceBranchType.base)
+        ).resolves.toMatchObject<Partial<ExtractedStats>>({
+          original: baseStats,
+        });
       });
 
       it('returns the head compilation stats when specified', () => {
-        return expect(dataSource.getCompilationStats(DataSourceBranchType.head)).resolves.toEqual(
-          headStats
-        );
+        return expect(
+          dataSource.getCompilationStats(DataSourceBranchType.head)
+        ).resolves.toMatchObject<Partial<ExtractedStats>>({
+          original: headStats,
+        });
       });
     });
 

--- a/src/dataSources/LocalFile/index.test.ts
+++ b/src/dataSources/LocalFile/index.test.ts
@@ -4,7 +4,7 @@
  */
 import fs from 'fs';
 import path from 'path';
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 
 import LocalFileDataSource, { LocalFileDataSourceConfiguration } from '.';
 
@@ -55,8 +55,8 @@ describe('LocalFileDataSource', () => {
   });
 
   describe('getCompilationStats()', () => {
-    const baseStats = (baseCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
-    const headStats = (headCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
+    const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+    const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
 
     describe('happy path', () => {
       beforeEach(() => {

--- a/src/dataSources/LocalFile/index.test.ts
+++ b/src/dataSources/LocalFile/index.test.ts
@@ -9,7 +9,6 @@ import LocalFileDataSource, { LocalFileDataSourceConfiguration } from '.';
 
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
-import { ExtractedStats } from '../../helpers/extractStats';
 import { Stats } from '../../types';
 import { DataSourceBranchType } from '../BaseDataSource';
 
@@ -79,17 +78,13 @@ describe('LocalFileDataSource', () => {
       it('returns the base compilation stats when specified', () => {
         return expect(
           dataSource.getCompilationStats(DataSourceBranchType.base)
-        ).resolves.toMatchObject<Partial<ExtractedStats>>({
-          original: baseStats,
-        });
+        ).resolves.toMatchObject<Partial<Stats>>(baseStats);
       });
 
       it('returns the head compilation stats when specified', () => {
         return expect(
           dataSource.getCompilationStats(DataSourceBranchType.head)
-        ).resolves.toMatchObject<Partial<ExtractedStats>>({
-          original: headStats,
-        });
+        ).resolves.toMatchObject<Partial<Stats>>(headStats);
       });
     });
 

--- a/src/dataSources/LocalFile/index.test.ts
+++ b/src/dataSources/LocalFile/index.test.ts
@@ -4,12 +4,12 @@
  */
 import fs from 'fs';
 import path from 'path';
-import webpack4 from 'webpack4';
 
 import LocalFileDataSource, { LocalFileDataSourceConfiguration } from '.';
 
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
+import { Stats4 } from '../../helpers/constants';
 import { DataSourceBranchType } from '../BaseDataSource';
 
 jest.mock('fs');
@@ -55,8 +55,8 @@ describe('LocalFileDataSource', () => {
   });
 
   describe('getCompilationStats()', () => {
-    const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
-    const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+    const baseStats = (baseCompilationStats as unknown) as Stats4;
+    const headStats = (headCompilationStats as unknown) as Stats4;
 
     describe('happy path', () => {
       beforeEach(() => {

--- a/src/dataSources/LocalFile/index.ts
+++ b/src/dataSources/LocalFile/index.ts
@@ -3,12 +3,11 @@
  * See LICENSE.md in the project root for license information.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
 import fs from 'fs';
 import path from 'path';
 
 import BaseDataSource, { DataSource, DataSourceBranchType } from '../BaseDataSource';
+import { Stats4 } from '../../helpers/constants';
 
 export interface LocalFileDataSourceConfiguration {
   baseFilePath: string;
@@ -41,16 +40,14 @@ export default class LocalFileDataSource extends BaseDataSource implements DataS
     }
   }
 
-  async getCompilationStats(
-    branchType: DataSourceBranchType
-  ): Promise<webpack4.Stats.ToJsonOutput> {
+  async getCompilationStats(branchType: DataSourceBranchType): Promise<Stats4> {
     let file: string;
     if (branchType === DataSourceBranchType.head) {
       file = await fs.promises.readFile(this.options.headFilePath, 'utf-8');
     } else {
       file = await fs.promises.readFile(this.options.baseFilePath, 'utf-8');
     }
-    const data = (JSON.parse(file) as unknown) as webpack4.Stats.ToJsonOutput;
+    const data = (JSON.parse(file) as unknown) as Stats4;
 
     this.validateCompilationStats(data);
 

--- a/src/dataSources/LocalFile/index.ts
+++ b/src/dataSources/LocalFile/index.ts
@@ -7,7 +7,8 @@ import fs from 'fs';
 import path from 'path';
 
 import BaseDataSource, { DataSource, DataSourceBranchType } from '../BaseDataSource';
-import { Stats4 } from '../../helpers/constants';
+import { Stats } from '../../helpers/constants';
+import extractStats, { ExtractedStats } from '../../helpers/extractStats';
 
 export interface LocalFileDataSourceConfiguration {
   baseFilePath: string;
@@ -40,17 +41,17 @@ export default class LocalFileDataSource extends BaseDataSource implements DataS
     }
   }
 
-  async getCompilationStats(branchType: DataSourceBranchType): Promise<Stats4> {
+  async getCompilationStats(branchType: DataSourceBranchType): Promise<ExtractedStats> {
     let file: string;
     if (branchType === DataSourceBranchType.head) {
       file = await fs.promises.readFile(this.options.headFilePath, 'utf-8');
     } else {
       file = await fs.promises.readFile(this.options.baseFilePath, 'utf-8');
     }
-    const data = (JSON.parse(file) as unknown) as Stats4;
+    const data = (JSON.parse(file) as unknown) as Stats;
 
     this.validateCompilationStats(data);
 
-    return data;
+    return extractStats(data);
   }
 }

--- a/src/dataSources/LocalFile/index.ts
+++ b/src/dataSources/LocalFile/index.ts
@@ -7,8 +7,8 @@ import fs from 'fs';
 import path from 'path';
 
 import BaseDataSource, { DataSource, DataSourceBranchType } from '../BaseDataSource';
-import { Stats } from '../../helpers/constants';
 import extractStats, { ExtractedStats } from '../../helpers/extractStats';
+import { Stats } from '../../types';
 
 export interface LocalFileDataSourceConfiguration {
   baseFilePath: string;

--- a/src/dataSources/LocalFile/index.ts
+++ b/src/dataSources/LocalFile/index.ts
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import fs from 'fs';
 import path from 'path';
 
@@ -41,14 +41,16 @@ export default class LocalFileDataSource extends BaseDataSource implements DataS
     }
   }
 
-  async getCompilationStats(branchType: DataSourceBranchType): Promise<webpack.Stats.ToJsonOutput> {
+  async getCompilationStats(
+    branchType: DataSourceBranchType
+  ): Promise<webpack4.Stats.ToJsonOutput> {
     let file: string;
     if (branchType === DataSourceBranchType.head) {
       file = await fs.promises.readFile(this.options.headFilePath, 'utf-8');
     } else {
       file = await fs.promises.readFile(this.options.baseFilePath, 'utf-8');
     }
-    const data = (JSON.parse(file) as unknown) as webpack.Stats.ToJsonOutput;
+    const data = (JSON.parse(file) as unknown) as webpack4.Stats.ToJsonOutput;
 
     this.validateCompilationStats(data);
 

--- a/src/dataSources/LocalFile/index.ts
+++ b/src/dataSources/LocalFile/index.ts
@@ -7,7 +7,6 @@ import fs from 'fs';
 import path from 'path';
 
 import BaseDataSource, { DataSource, DataSourceBranchType } from '../BaseDataSource';
-import extractStats, { ExtractedStats } from '../../helpers/extractStats';
 import { Stats } from '../../types';
 
 export interface LocalFileDataSourceConfiguration {
@@ -41,7 +40,7 @@ export default class LocalFileDataSource extends BaseDataSource implements DataS
     }
   }
 
-  async getCompilationStats(branchType: DataSourceBranchType): Promise<ExtractedStats> {
+  async getCompilationStats(branchType: DataSourceBranchType): Promise<Stats> {
     let file: string;
     if (branchType === DataSourceBranchType.head) {
       file = await fs.promises.readFile(this.options.headFilePath, 'utf-8');
@@ -52,6 +51,6 @@ export default class LocalFileDataSource extends BaseDataSource implements DataS
 
     this.validateCompilationStats(data);
 
-    return extractStats(data);
+    return data;
   }
 }

--- a/src/dataSources/README.md
+++ b/src/dataSources/README.md
@@ -19,6 +19,7 @@ Every data source should do the following:
 If a data source requires extending, or a new data source is needed please feel free to raise a PR (more the merrier).
 
 Present data sources:
+
 - [LocalFile](LocalFile.ts)
 - [TeamCity](TeamCity.ts)
 
@@ -26,7 +27,7 @@ Present data sources:
 
 All data sources are accessible via the root import, as `<name>DataSource` (i.e. [TeamCity](./TeamCity) is available as `TeamCityDataSource`):
 
-```
+``` javascript
 import { TeamCityDataSource } from 'webpack-bundle-delta';
 ```
 

--- a/src/dataSources/README.md
+++ b/src/dataSources/README.md
@@ -12,7 +12,7 @@ Every data source should do the following:
   - implement `getCompilationStats()` in the extending base class
     - Failure to do so will cause an error to be thrown
     - Use `this.validateCompilationStats` to validate the data (ensuring the correct webpack stats properties are there)
-    - Pass the stats to [`extractStats`](../helpers/extractStats.ts) and return the result
+    - Return the stats
   - make this the default export in the folder's `index.ts` file
 - Implement a `cli.ts` which follows the [`CliProgram`](../CliProgram.ts) interface:
   - Refer to [`commander`'s Action handler (sub)commands](https://github.com/tj/commander.js#action-handler-subcommands) for setting up your command

--- a/src/dataSources/README.md
+++ b/src/dataSources/README.md
@@ -9,7 +9,10 @@ As not all teams/organisations will have the same approach, having a uniform way
 Every data source should do the following:
 
 - Create a class extending the [`BaseDataSource`](BaseDataSource.ts):
-  - implement `getCompilationStats()` in the extending base class, failure to do so will cause an error to be thrown. Also, use `this.validateCompilationStats` to validate the data before turning it (to ensure the correct webpack stats properties are there)
+  - implement `getCompilationStats()` in the extending base class
+    - Failure to do so will cause an error to be thrown
+    - Use `this.validateCompilationStats` to validate the data (ensuring the correct webpack stats properties are there)
+    - Pass the stats to [`extractStats`](../helpers/extractStats.ts) and return the result
   - make this the default export in the folder's `index.ts` file
 - Implement a `cli.ts` which follows the [`CliProgram`](../CliProgram.ts) interface:
   - Refer to [`commander`'s Action handler (sub)commands](https://github.com/tj/commander.js#action-handler-subcommands) for setting up your command

--- a/src/dataSources/TeamCity/index.test.ts
+++ b/src/dataSources/TeamCity/index.test.ts
@@ -8,7 +8,6 @@ import TeamCityDataSource, { TeamCityDataSourceConfiguration } from '.';
 import { DataSourceBranchType } from '../BaseDataSource';
 
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
-import { ExtractedStats } from '../../helpers/extractStats';
 import { Stats } from '../../types';
 
 jest.mock('axios');
@@ -82,9 +81,7 @@ describe('TeamCityDataSource', () => {
       it('returns back the stats', () => {
         return expect(
           dataSource.getCompilationStats(DataSourceBranchType.head, 'some-sha')
-        ).resolves.toMatchObject<Partial<ExtractedStats>>({
-          original: baseStats,
-        });
+        ).resolves.toMatchObject<Stats>(baseStats);
       });
     });
 

--- a/src/dataSources/TeamCity/index.test.ts
+++ b/src/dataSources/TeamCity/index.test.ts
@@ -4,11 +4,11 @@
  */
 import axios from 'axios';
 
-import webpack4 from 'webpack4';
 import TeamCityDataSource, { TeamCityDataSourceConfiguration } from '.';
 import { DataSourceBranchType } from '../BaseDataSource';
 
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
+import { Stats4 } from '../../helpers/constants';
 
 jest.mock('axios');
 
@@ -32,7 +32,7 @@ describe('TeamCityDataSource', () => {
   });
 
   describe('getCompilationStats()', () => {
-    const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+    const baseStats = (baseCompilationStats as unknown) as Stats4;
 
     describe('happy path', () => {
       beforeEach(() => {

--- a/src/dataSources/TeamCity/index.test.ts
+++ b/src/dataSources/TeamCity/index.test.ts
@@ -8,8 +8,8 @@ import TeamCityDataSource, { TeamCityDataSourceConfiguration } from '.';
 import { DataSourceBranchType } from '../BaseDataSource';
 
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
-import { Stats } from '../../helpers/constants';
 import { ExtractedStats } from '../../helpers/extractStats';
+import { Stats } from '../../types';
 
 jest.mock('axios');
 

--- a/src/dataSources/TeamCity/index.test.ts
+++ b/src/dataSources/TeamCity/index.test.ts
@@ -4,7 +4,7 @@
  */
 import axios from 'axios';
 
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import TeamCityDataSource, { TeamCityDataSourceConfiguration } from '.';
 import { DataSourceBranchType } from '../BaseDataSource';
 
@@ -32,7 +32,7 @@ describe('TeamCityDataSource', () => {
   });
 
   describe('getCompilationStats()', () => {
-    const baseStats = (baseCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
+    const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
 
     describe('happy path', () => {
       beforeEach(() => {

--- a/src/dataSources/TeamCity/index.test.ts
+++ b/src/dataSources/TeamCity/index.test.ts
@@ -8,7 +8,7 @@ import TeamCityDataSource, { TeamCityDataSourceConfiguration } from '.';
 import { DataSourceBranchType } from '../BaseDataSource';
 
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
-import { Stats4 } from '../../helpers/constants';
+import { Stats } from '../../helpers/constants';
 import { ExtractedStats } from '../../helpers/extractStats';
 
 jest.mock('axios');
@@ -33,7 +33,7 @@ describe('TeamCityDataSource', () => {
   });
 
   describe('getCompilationStats()', () => {
-    const baseStats = (baseCompilationStats as unknown) as Stats4;
+    const baseStats = (baseCompilationStats as unknown) as Stats;
 
     describe('happy path', () => {
       beforeEach(() => {

--- a/src/dataSources/TeamCity/index.test.ts
+++ b/src/dataSources/TeamCity/index.test.ts
@@ -9,6 +9,7 @@ import { DataSourceBranchType } from '../BaseDataSource';
 
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import { Stats4 } from '../../helpers/constants';
+import { ExtractedStats } from '../../helpers/extractStats';
 
 jest.mock('axios');
 
@@ -78,10 +79,12 @@ describe('TeamCityDataSource', () => {
         );
       });
 
-      it('returns back the stats', async () => {
-        const data = await dataSource.getCompilationStats(DataSourceBranchType.head, 'some-sha');
-
-        expect(data).toEqual(baseStats);
+      it('returns back the stats', () => {
+        return expect(
+          dataSource.getCompilationStats(DataSourceBranchType.head, 'some-sha')
+        ).resolves.toMatchObject<Partial<ExtractedStats>>({
+          original: baseStats,
+        });
       });
     });
 

--- a/src/dataSources/TeamCity/index.ts
+++ b/src/dataSources/TeamCity/index.ts
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import axios, { AxiosResponse } from 'axios';
 import BaseDataSource, { DataSource, DataSourceBranchType } from '../BaseDataSource';
 
@@ -28,7 +28,7 @@ export default class TeamCityDataSource extends BaseDataSource implements DataSo
   async getCompilationStats(
     _branchType: DataSourceBranchType,
     sha: string
-  ): Promise<webpack.Stats.ToJsonOutput> {
+  ): Promise<webpack4.Stats.ToJsonOutput> {
     const {
       serverUrl,
       username,
@@ -36,7 +36,7 @@ export default class TeamCityDataSource extends BaseDataSource implements DataSo
       buildType,
       fileName = 'compilation-stats.json',
     } = this.options;
-    const { data } = await axios.get<unknown, AxiosResponse<webpack.Stats.ToJsonOutput>>(
+    const { data } = await axios.get<unknown, AxiosResponse<webpack4.Stats.ToJsonOutput>>(
       `${serverUrl}/app/rest/builds/buildType:${buildType},branch:default:any,revision:${sha}/artifacts/content/${fileName}`,
       {
         auth: {

--- a/src/dataSources/TeamCity/index.ts
+++ b/src/dataSources/TeamCity/index.ts
@@ -5,7 +5,6 @@
 
 import axios, { AxiosResponse } from 'axios';
 import BaseDataSource, { DataSource, DataSourceBranchType } from '../BaseDataSource';
-import extractStats, { ExtractedStats } from '../../helpers/extractStats';
 import { Stats } from '../../types';
 
 export interface TeamCityDataSourceConfiguration {
@@ -25,10 +24,7 @@ export default class TeamCityDataSource extends BaseDataSource implements DataSo
     this.options = options;
   }
 
-  async getCompilationStats(
-    _branchType: DataSourceBranchType,
-    sha: string
-  ): Promise<ExtractedStats> {
+  async getCompilationStats(_branchType: DataSourceBranchType, sha: string): Promise<Stats> {
     const {
       serverUrl,
       username,
@@ -48,6 +44,6 @@ export default class TeamCityDataSource extends BaseDataSource implements DataSo
 
     this.validateCompilationStats(data);
 
-    return extractStats(data);
+    return data;
   }
 }

--- a/src/dataSources/TeamCity/index.ts
+++ b/src/dataSources/TeamCity/index.ts
@@ -5,8 +5,8 @@
 
 import axios, { AxiosResponse } from 'axios';
 import BaseDataSource, { DataSource, DataSourceBranchType } from '../BaseDataSource';
-import { Stats } from '../../helpers/constants';
 import extractStats, { ExtractedStats } from '../../helpers/extractStats';
+import { Stats } from '../../types';
 
 export interface TeamCityDataSourceConfiguration {
   serverUrl: string;

--- a/src/dataSources/TeamCity/index.ts
+++ b/src/dataSources/TeamCity/index.ts
@@ -5,7 +5,8 @@
 
 import axios, { AxiosResponse } from 'axios';
 import BaseDataSource, { DataSource, DataSourceBranchType } from '../BaseDataSource';
-import { Stats4 } from '../../helpers/constants';
+import { Stats } from '../../helpers/constants';
+import extractStats, { ExtractedStats } from '../../helpers/extractStats';
 
 export interface TeamCityDataSourceConfiguration {
   serverUrl: string;
@@ -24,7 +25,10 @@ export default class TeamCityDataSource extends BaseDataSource implements DataSo
     this.options = options;
   }
 
-  async getCompilationStats(_branchType: DataSourceBranchType, sha: string): Promise<Stats4> {
+  async getCompilationStats(
+    _branchType: DataSourceBranchType,
+    sha: string
+  ): Promise<ExtractedStats> {
     const {
       serverUrl,
       username,
@@ -32,7 +36,7 @@ export default class TeamCityDataSource extends BaseDataSource implements DataSo
       buildType,
       fileName = 'compilation-stats.json',
     } = this.options;
-    const { data } = await axios.get<unknown, AxiosResponse<Stats4>>(
+    const { data } = await axios.get<unknown, AxiosResponse<Stats>>(
       `${serverUrl}/app/rest/builds/buildType:${buildType},branch:default:any,revision:${sha}/artifacts/content/${fileName}`,
       {
         auth: {
@@ -44,6 +48,6 @@ export default class TeamCityDataSource extends BaseDataSource implements DataSo
 
     this.validateCompilationStats(data);
 
-    return data;
+    return extractStats(data);
   }
 }

--- a/src/dataSources/TeamCity/index.ts
+++ b/src/dataSources/TeamCity/index.ts
@@ -3,10 +3,9 @@
  * See LICENSE.md in the project root for license information.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
 import axios, { AxiosResponse } from 'axios';
 import BaseDataSource, { DataSource, DataSourceBranchType } from '../BaseDataSource';
+import { Stats4 } from '../../helpers/constants';
 
 export interface TeamCityDataSourceConfiguration {
   serverUrl: string;
@@ -25,10 +24,7 @@ export default class TeamCityDataSource extends BaseDataSource implements DataSo
     this.options = options;
   }
 
-  async getCompilationStats(
-    _branchType: DataSourceBranchType,
-    sha: string
-  ): Promise<webpack4.Stats.ToJsonOutput> {
+  async getCompilationStats(_branchType: DataSourceBranchType, sha: string): Promise<Stats4> {
     const {
       serverUrl,
       username,
@@ -36,7 +32,7 @@ export default class TeamCityDataSource extends BaseDataSource implements DataSo
       buildType,
       fileName = 'compilation-stats.json',
     } = this.options;
-    const { data } = await axios.get<unknown, AxiosResponse<webpack4.Stats.ToJsonOutput>>(
+    const { data } = await axios.get<unknown, AxiosResponse<Stats4>>(
       `${serverUrl}/app/rest/builds/buildType:${buildType},branch:default:any,revision:${sha}/artifacts/content/${fileName}`,
       {
         auth: {

--- a/src/helpers/MergeCompilationStatsWebpackPlugin.ts
+++ b/src/helpers/MergeCompilationStatsWebpackPlugin.ts
@@ -7,6 +7,7 @@
 import webpack4 from 'webpack4';
 import { join } from 'path';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { Stats4 } from './constants';
 
 /**
  * Options for MergeCompilationStatsWebpackPlugin
@@ -51,7 +52,7 @@ export default class MergeCompilationStatsWebpackPlugin {
     const { assetsPath, inputFiles, filename } = this.options;
 
     compiler.hooks.done.tap('Merge Compiled Stats Plugin', () => {
-      const allStats: webpack4.Stats.ToJsonOutput = {
+      const allStats: Stats4 = {
         _showErrors: false,
         _showWarnings: false,
         errors: [],

--- a/src/helpers/MergeCompilationStatsWebpackPlugin.ts
+++ b/src/helpers/MergeCompilationStatsWebpackPlugin.ts
@@ -7,7 +7,7 @@
 import webpack from 'webpack';
 import { join } from 'path';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { Stats } from './constants';
+import { Stats } from '../types';
 
 /**
  * Options for MergeCompilationStatsWebpackPlugin

--- a/src/helpers/MergeCompilationStatsWebpackPlugin.ts
+++ b/src/helpers/MergeCompilationStatsWebpackPlugin.ts
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import { join } from 'path';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 
@@ -47,11 +47,11 @@ export default class MergeCompilationStatsWebpackPlugin {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  apply(compiler: webpack.Compiler): void {
+  apply(compiler: webpack4.Compiler): void {
     const { assetsPath, inputFiles, filename } = this.options;
 
     compiler.hooks.done.tap('Merge Compiled Stats Plugin', () => {
-      const allStats: webpack.Stats.ToJsonOutput = {
+      const allStats: webpack4.Stats.ToJsonOutput = {
         _showErrors: false,
         _showWarnings: false,
         errors: [],

--- a/src/helpers/MergeCompilationStatsWebpackPlugin.ts
+++ b/src/helpers/MergeCompilationStatsWebpackPlugin.ts
@@ -4,10 +4,10 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
+import webpack from 'webpack';
 import { join } from 'path';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { Stats4 } from './constants';
+import { Stats } from './constants';
 
 /**
  * Options for MergeCompilationStatsWebpackPlugin
@@ -48,17 +48,19 @@ export default class MergeCompilationStatsWebpackPlugin {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  apply(compiler: webpack4.Compiler): void {
+  apply(compiler: webpack.Compiler): void {
     const { assetsPath, inputFiles, filename } = this.options;
 
     compiler.hooks.done.tap('Merge Compiled Stats Plugin', () => {
-      const allStats: Stats4 = {
-        _showErrors: false,
-        _showWarnings: false,
-        errors: [],
-        warnings: [],
-        children: [],
-      };
+      const allStats: Stats = webpack.version.startsWith('4.')
+        ? {
+            _showErrors: false,
+            _showWarnings: false,
+            errors: [],
+            warnings: [],
+            children: [],
+          }
+        : {};
       inputFiles.forEach((file) => {
         const filePath = join(assetsPath, file);
         if (existsSync(filePath)) {

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -11,8 +11,12 @@ import webpack4 from 'webpack4';
 export type Stats5 = ReturnType<webpack.Stats['toJson']>;
 export type Stats4 = webpack4.Stats.ToJsonOutput;
 export type Stats = Stats5 | Stats4;
-export type Asset = Stats4['assets'][0] | Stats5['assets'][0];
-export type Module = Stats4['modules'][0] | Stats5['modules'][0];
+export type Asset5 = Stats5['assets'][0];
+export type Asset4 = Stats4['assets'][0];
+export type Asset = Asset5 | Asset4;
+export type Module5 = Stats5['modules'][0];
+export type Module4 = Stats4['modules'][0];
+export type Module = Module5 | Module4;
 
 export const FILENAME_QUERY_REGEXP = /\?.*$/u;
 export const FILENAME_JS_MJS_EXTENSIONS = /\.(js|mjs)$/iu;

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -3,21 +3,6 @@
  * See LICENSE.md in the project root for license information.
  */
 
-/* eslint-disable import/no-extraneous-dependencies */
-import webpack from 'webpack';
-import webpack4 from 'webpack4';
-/* eslint-enable import/no-extraneous-dependencies */
-
-export type Stats5 = ReturnType<webpack.Stats['toJson']>;
-export type Stats4 = webpack4.Stats.ToJsonOutput;
-export type Stats = Stats5 | Stats4;
-export type Asset5 = Stats5['assets'][0];
-export type Asset4 = Stats4['assets'][0];
-export type Asset = Asset5 | Asset4;
-export type Module5 = Stats5['modules'][0];
-export type Module4 = Stats4['modules'][0];
-export type Module = Module5 | Module4;
-
 export const FILENAME_QUERY_REGEXP = /\?.*$/u;
 export const FILENAME_JS_MJS_EXTENSIONS = /\.(js|mjs)$/iu;
 export const FILENAME_JS_MJS_CSS_EXTENSIONS = /\.(js|mjs|css)$/iu;

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -3,6 +3,17 @@
  * See LICENSE.md in the project root for license information.
  */
 
+/* eslint-disable import/no-extraneous-dependencies */
+import webpack from 'webpack';
+import webpack4 from 'webpack4';
+/* eslint-enable import/no-extraneous-dependencies */
+
+export type Stats5 = ReturnType<webpack.Stats['toJson']>;
+export type Stats4 = webpack4.Stats.ToJsonOutput;
+export type Stats = Stats5 | Stats4;
+export type Asset = Stats4['assets'][0] | Stats5['assets'][0];
+export type Module = Stats4['modules'][0] | Stats5['modules'][0];
+
 export const FILENAME_QUERY_REGEXP = /\?.*$/u;
 export const FILENAME_JS_MJS_EXTENSIONS = /\.(js|mjs)$/iu;
 export const FILENAME_JS_MJS_CSS_EXTENSIONS = /\.(js|mjs|css)$/iu;

--- a/src/helpers/extractStats.test.ts
+++ b/src/helpers/extractStats.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import { Stats4, Stats5 } from './constants';
+import { Stats4, Stats5 } from '../types';
 import extractStats, { ExtractedStats4, ExtractedStats5 } from './extractStats';
 
 const baseStats: Stats5 = {

--- a/src/helpers/extractStats.test.ts
+++ b/src/helpers/extractStats.test.ts
@@ -2,69 +2,215 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack4 from 'webpack4';
-import extractStats from './extractStats';
+import { Stats4, Stats5 } from './constants';
+import extractStats, { ExtractedStats4, ExtractedStats5 } from './extractStats';
 
-const baseStats: webpack4.Stats.ToJsonOutput = {
+const baseStats: Stats5 = {
+  version: '5.9.0',
+};
+
+const asset: Stats5['assets'][0] = {
+  type: 'asset',
+  name: 'main.js',
+  size: 10000,
+  chunkNames: [],
+  chunkIdHints: [],
+  auxiliaryChunkNames: ['backgrounds'],
+  auxiliaryChunkIdHints: [],
+  emitted: false,
+  comparedForEmit: false,
+  cached: true,
+  info: {},
+  related: {},
+  chunks: [],
+  auxiliaryChunks: [4231],
+  isOverSizeLimit: false,
+};
+
+const statsWithAssets: Stats5 = {
+  ...baseStats,
+  assets: [asset],
+};
+
+const statsWithAssetsAndChildren: Stats5 = {
+  ...baseStats,
+  assets: [asset],
+  children: [
+    {
+      ...baseStats,
+      assets: [
+        {
+          ...asset,
+          name: 'child.js',
+          size: 1000,
+        },
+      ],
+    },
+  ],
+};
+
+const base4Stats: Stats4 = {
+  version: '4.44.0',
   _showErrors: false,
   _showWarnings: false,
   errors: [],
   warnings: [],
 };
 
-const statsWithAssets: webpack4.Stats.ToJsonOutput = {
-  ...baseStats,
-  assets: [
-    {
-      name: '3b1c17aaa00d5f277227fae592484408.jpg',
-      size: 9705,
-      chunks: [],
-      chunkNames: [],
-      emitted: true,
-    },
-  ],
+const stats4Asset: Stats4['assets'][0] = {
+  name: 'main.js',
+  size: 10000,
+  chunks: [],
+  chunkNames: [],
+  emitted: true,
 };
 
-const statsWithAssetsAndChildren: webpack4.Stats.ToJsonOutput = {
-  ...baseStats,
-  assets: [
+const stats4WithAssets: Stats4 = {
+  ...base4Stats,
+  assets: [stats4Asset],
+};
+
+const stats4WithAssetsAndChildren: Stats4 = {
+  ...base4Stats,
+  assets: [stats4Asset],
+  children: [
     {
-      name: '3b1c17aaa00d5f277227fae592484408.jpg',
-      size: 9705,
-      chunks: [],
-      chunkNames: [],
-      emitted: true,
+      ...base4Stats,
+      assets: [
+        {
+          ...stats4Asset,
+          name: 'child.js',
+          size: 1000,
+        },
+      ],
     },
   ],
-  children: [],
 };
 
 describe('extractStats', () => {
-  it('returns stats (single compile - no assets, no children)', () => {
-    expect(extractStats(baseStats)).toEqual([baseStats]);
+  describe('webpack v5', () => {
+    it('returns stats (single compile - no assets, no children)', () => {
+      expect(extractStats(baseStats)).toEqual<ExtractedStats5>({
+        majorVersion: 5,
+        stats: [baseStats],
+        original: baseStats,
+      });
+    });
+
+    it('returns stats (single compile - assets, no children, no version)', () => {
+      const noVersionStats = {
+        ...statsWithAssets,
+      } as Stats5;
+      delete noVersionStats.version;
+
+      expect(extractStats(noVersionStats)).toEqual<ExtractedStats5>({
+        majorVersion: 5,
+        stats: [noVersionStats],
+        original: noVersionStats,
+      });
+    });
+
+    it('returns stats (single compile - assets, no children)', () => {
+      expect(extractStats(statsWithAssets)).toEqual<ExtractedStats5>({
+        majorVersion: 5,
+        stats: [statsWithAssets],
+        original: statsWithAssets,
+      });
+    });
+
+    it('returns stats (single compile - assets, children', () => {
+      expect(extractStats(statsWithAssetsAndChildren)).toEqual<ExtractedStats5>({
+        majorVersion: 5,
+        stats: [statsWithAssetsAndChildren],
+        original: statsWithAssetsAndChildren,
+      });
+    });
+
+    it('returns stats (multi compile)', () => {
+      const children = [statsWithAssets, statsWithAssetsAndChildren];
+      const multiCompileStats: Stats5 = {
+        ...baseStats,
+        children,
+      };
+
+      expect(extractStats(multiCompileStats)).toEqual<ExtractedStats5>({
+        majorVersion: 5,
+        stats: children,
+        original: multiCompileStats,
+      });
+    });
+
+    it('returns stats (parallel-webpack --profile --json flags)', () => {
+      const children = [statsWithAssets, statsWithAssetsAndChildren];
+
+      expect(extractStats(children)).toEqual<ExtractedStats5>({
+        majorVersion: 5,
+        stats: children,
+        original: children as unknown,
+      });
+    });
   });
 
-  it('returns stats (single compile - assets, no children)', () => {
-    expect(extractStats(statsWithAssets)).toEqual([statsWithAssets]);
-  });
+  describe('webpack v4', () => {
+    it('returns stats (single compile - no assets, no children)', () => {
+      expect(extractStats(base4Stats)).toEqual<ExtractedStats4>({
+        majorVersion: 4,
+        stats: [base4Stats],
+        original: base4Stats,
+      });
+    });
 
-  it('returns stats (single compile - assets, children', () => {
-    expect(extractStats(statsWithAssetsAndChildren)).toEqual([statsWithAssetsAndChildren]);
-  });
+    it('returns stats (single compile - assets, no children, no version)', () => {
+      const noVersionStats = {
+        ...stats4WithAssets,
+      } as Stats4;
+      delete noVersionStats.version;
 
-  it('returns stats (multi compile)', () => {
-    const children = [statsWithAssets, statsWithAssetsAndChildren];
-    const multiCompileStats: webpack4.Stats.ToJsonOutput = {
-      ...baseStats,
-      children,
-    };
+      expect(extractStats(noVersionStats)).toEqual<ExtractedStats4>({
+        majorVersion: 4,
+        stats: [noVersionStats],
+        original: noVersionStats,
+      });
+    });
 
-    expect(extractStats(multiCompileStats)).toEqual(children);
-  });
+    it('returns stats (single compile - assets, no children)', () => {
+      expect(extractStats(stats4WithAssets)).toEqual<ExtractedStats4>({
+        majorVersion: 4,
+        stats: [stats4WithAssets],
+        original: stats4WithAssets,
+      });
+    });
 
-  it('returns stats (parallel-webpack --profile --json flags)', () => {
-    const children = [statsWithAssets, statsWithAssetsAndChildren];
+    it('returns stats (single compile - assets, children', () => {
+      expect(extractStats(stats4WithAssetsAndChildren)).toEqual<ExtractedStats4>({
+        majorVersion: 4,
+        stats: [stats4WithAssetsAndChildren],
+        original: stats4WithAssetsAndChildren,
+      });
+    });
 
-    expect(extractStats(children)).toEqual(children);
+    it('returns stats (multi compile)', () => {
+      const children = [stats4WithAssets, stats4WithAssetsAndChildren];
+      const multiCompileStats: Stats4 = {
+        ...base4Stats,
+        children,
+      };
+
+      expect(extractStats(multiCompileStats)).toEqual<ExtractedStats4>({
+        majorVersion: 4,
+        stats: children,
+        original: multiCompileStats,
+      });
+    });
+
+    it('returns stats (parallel-webpack --profile --json flags)', () => {
+      const children = [stats4WithAssets, stats4WithAssetsAndChildren];
+
+      expect(extractStats(children)).toEqual<ExtractedStats4>({
+        majorVersion: 4,
+        stats: children,
+        original: children as unknown,
+      });
+    });
   });
 });

--- a/src/helpers/extractStats.test.ts
+++ b/src/helpers/extractStats.test.ts
@@ -2,17 +2,17 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import extractStats from './extractStats';
 
-const baseStats: webpack.Stats.ToJsonOutput = {
+const baseStats: webpack4.Stats.ToJsonOutput = {
   _showErrors: false,
   _showWarnings: false,
   errors: [],
   warnings: [],
 };
 
-const statsWithAssets: webpack.Stats.ToJsonOutput = {
+const statsWithAssets: webpack4.Stats.ToJsonOutput = {
   ...baseStats,
   assets: [
     {
@@ -25,7 +25,7 @@ const statsWithAssets: webpack.Stats.ToJsonOutput = {
   ],
 };
 
-const statsWithAssetsAndChildren: webpack.Stats.ToJsonOutput = {
+const statsWithAssetsAndChildren: webpack4.Stats.ToJsonOutput = {
   ...baseStats,
   assets: [
     {
@@ -54,7 +54,7 @@ describe('extractStats', () => {
 
   it('returns stats (multi compile)', () => {
     const children = [statsWithAssets, statsWithAssetsAndChildren];
-    const multiCompileStats: webpack.Stats.ToJsonOutput = {
+    const multiCompileStats: webpack4.Stats.ToJsonOutput = {
       ...baseStats,
       children,
     };

--- a/src/helpers/extractStats.test.ts
+++ b/src/helpers/extractStats.test.ts
@@ -21,7 +21,6 @@ const asset: Stats5['assets'][0] = {
   comparedForEmit: false,
   cached: true,
   info: {},
-  related: {},
   chunks: [],
   auxiliaryChunks: [4231],
   isOverSizeLimit: false,

--- a/src/helpers/extractStats.ts
+++ b/src/helpers/extractStats.ts
@@ -4,13 +4,13 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 
 const extractStats = (
-  compilationStats: webpack.Stats.ToJsonOutput | webpack.Stats.ToJsonOutput[]
-): webpack.Stats.ToJsonOutput[] => {
+  compilationStats: webpack4.Stats.ToJsonOutput | webpack4.Stats.ToJsonOutput[]
+): webpack4.Stats.ToJsonOutput[] => {
   if (Array.isArray(compilationStats)) {
-    return compilationStats as webpack.Stats.ToJsonOutput[];
+    return compilationStats as webpack4.Stats.ToJsonOutput[];
   }
 
   if (!compilationStats.assets && compilationStats.children && compilationStats.children.length) {

--- a/src/helpers/extractStats.ts
+++ b/src/helpers/extractStats.ts
@@ -3,21 +3,85 @@
  * See LICENSE.md in the project root for license information.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
+import { Stats, Stats4, Stats5 } from './constants';
 
-const extractStats = (
-  compilationStats: webpack4.Stats.ToJsonOutput | webpack4.Stats.ToJsonOutput[]
-): webpack4.Stats.ToJsonOutput[] => {
+export type ExtractedStats = ExtractedStats5 | ExtractedStats4;
+
+interface BaseExtractedStats {
+  majorVersion: 4 | 5;
+  stats: Stats[];
+  original: Stats;
+}
+
+export interface ExtractedStats5 extends BaseExtractedStats {
+  majorVersion: 5;
+  stats: Stats5[];
+  original: Stats;
+}
+
+export interface ExtractedStats4 extends BaseExtractedStats {
+  majorVersion: 4;
+  stats: Stats4[];
+  original: Stats;
+}
+
+const isVersion4Stats = (stats: Stats) => {
+  if (stats?.version?.startsWith('5.')) {
+    return false;
+  }
+
+  return typeof (stats as Stats5).assets?.[0]?.type === 'undefined';
+};
+
+const extractStats = (compilationStats: Stats | Stats[]): ExtractedStats => {
+  // parallel-webpack output
   if (Array.isArray(compilationStats)) {
-    return compilationStats as webpack4.Stats.ToJsonOutput[];
+    const singleStats = compilationStats[0];
+    if (isVersion4Stats(singleStats)) {
+      return {
+        majorVersion: 4,
+        stats: compilationStats as Stats4[],
+        original: compilationStats as unknown,
+      } as ExtractedStats4;
+    }
+
+    return {
+      majorVersion: 5,
+      stats: compilationStats as Stats5[],
+      original: compilationStats as unknown,
+    } as ExtractedStats5;
   }
 
   if (!compilationStats.assets && compilationStats.children && compilationStats.children.length) {
-    return compilationStats.children;
+    const singleStats = compilationStats.children[0];
+    if (isVersion4Stats(singleStats)) {
+      return {
+        majorVersion: 4,
+        stats: compilationStats.children as Stats4[],
+        original: compilationStats as unknown,
+      } as ExtractedStats4;
+    }
+
+    return {
+      majorVersion: 5,
+      stats: compilationStats.children as Stats5[],
+      original: compilationStats as unknown,
+    } as ExtractedStats5;
   }
 
-  return [compilationStats];
+  if (isVersion4Stats(compilationStats)) {
+    return {
+      majorVersion: 4,
+      stats: [compilationStats] as Stats4[],
+      original: compilationStats as unknown,
+    } as ExtractedStats4;
+  }
+
+  return {
+    majorVersion: 5,
+    stats: [compilationStats] as Stats5[],
+    original: compilationStats as unknown,
+  } as ExtractedStats5;
 };
 
 export default extractStats;

--- a/src/helpers/extractStats.ts
+++ b/src/helpers/extractStats.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import { Stats, Stats4, Stats5 } from './constants';
+import { Stats, Stats4, Stats5 } from '../types';
 
 export type ExtractedStats = ExtractedStats5 | ExtractedStats4;
 

--- a/src/helpers/getNameFromAsset.test.ts
+++ b/src/helpers/getNameFromAsset.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license information.
  */
 import { defaultBasePluginConfig } from '../config/PluginConfig';
-import { Asset } from './constants';
+import { Asset } from '../types';
 import getNameFromAsset from './getNameFromAsset';
 
 const baseAsset = {

--- a/src/helpers/getNameFromAsset.test.ts
+++ b/src/helpers/getNameFromAsset.test.ts
@@ -3,7 +3,8 @@
  * See LICENSE.md in the project root for license information.
  */
 import { defaultBasePluginConfig } from '../config/PluginConfig';
-import getNameFromAsset, { Asset } from './getNameFromAsset';
+import { Asset } from './constants';
+import getNameFromAsset from './getNameFromAsset';
 
 const baseAsset = {
   name: '',
@@ -12,14 +13,14 @@ const baseAsset = {
   chunkNames: [],
   info: { immutable: true, minimized: true, size: 1608 },
   emitted: true,
-} as typeof Asset;
+} as Asset;
 
 describe('getNameFromAsset()', () => {
   it('returns name based on specified single chunkName', () => {
     const asset = {
       ...baseAsset,
       chunkNames: ['main'],
-    } as typeof Asset;
+    } as Asset;
 
     expect(getNameFromAsset(asset)).toBe('main');
   });
@@ -28,7 +29,7 @@ describe('getNameFromAsset()', () => {
     const asset = {
       ...baseAsset,
       chunkNames: ['main', 'another'],
-    } as typeof Asset;
+    } as Asset;
 
     expect(getNameFromAsset(asset)).toBe('main+another');
   });
@@ -38,7 +39,7 @@ describe('getNameFromAsset()', () => {
       const asset = {
         ...baseAsset,
         name: 'main.js',
-      } as typeof Asset;
+      } as Asset;
 
       expect(getNameFromAsset(asset, defaultBasePluginConfig.chunkFilename)).toBe('main');
     });
@@ -47,7 +48,7 @@ describe('getNameFromAsset()', () => {
       const asset = {
         ...baseAsset,
         name: 'main.js',
-      } as typeof Asset;
+      } as Asset;
 
       expect(getNameFromAsset(asset, defaultBasePluginConfig.chunkFilename, true)).toBe('main.js');
     });
@@ -57,7 +58,7 @@ describe('getNameFromAsset()', () => {
       const asset = {
         ...baseAsset,
         name: 'main-012abc345def.mjs',
-      } as typeof Asset;
+      } as Asset;
 
       expect(getNameFromAsset(asset, chunkFilename)).toBe('main-[hash]');
     });
@@ -67,7 +68,7 @@ describe('getNameFromAsset()', () => {
       const asset = {
         ...baseAsset,
         name: 'main-012abc345def.mjs',
-      } as typeof Asset;
+      } as Asset;
 
       expect(getNameFromAsset(asset, chunkFilename, true)).toBe('main-[hash].mjs');
     });
@@ -77,7 +78,7 @@ describe('getNameFromAsset()', () => {
       const asset = {
         ...baseAsset,
         name: 'static/js/main.11111111.js',
-      } as typeof Asset;
+      } as Asset;
 
       expect(getNameFromAsset(asset, chunkFilename)).toBe('static/js/main.[contenthash:8]');
     });
@@ -87,7 +88,7 @@ describe('getNameFromAsset()', () => {
       const asset = {
         ...baseAsset,
         name: 'static/js/main.11111111.js',
-      } as typeof Asset;
+      } as Asset;
 
       expect(getNameFromAsset(asset, chunkFilename, true)).toBe(
         'static/js/main.[contenthash:8].js'
@@ -99,7 +100,7 @@ describe('getNameFromAsset()', () => {
       const asset = {
         ...baseAsset,
         name: 'static/css/main.11111111.css',
-      } as typeof Asset;
+      } as Asset;
 
       expect(getNameFromAsset(asset, chunkFilename)).toBe('static/css/main.11111111');
     });
@@ -109,7 +110,7 @@ describe('getNameFromAsset()', () => {
       const asset = {
         ...baseAsset,
         name: 'static/css/main.11111111.css',
-      } as typeof Asset;
+      } as Asset;
 
       expect(getNameFromAsset(asset, chunkFilename, true)).toBe('static/css/main.11111111.css');
     });

--- a/src/helpers/getNameFromAsset.ts
+++ b/src/helpers/getNameFromAsset.ts
@@ -2,15 +2,12 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
 import { escapeRegExp } from 'lodash';
 import { defaultBasePluginConfig } from '../config/PluginConfig';
-
-export const Asset = ({ assets: [{}] } as webpack4.Stats.ToJsonOutput).assets[0];
+import { Asset } from './constants';
 
 const getNameFromAsset = (
-  asset: typeof Asset,
+  asset: Asset,
   chunkFilename = defaultBasePluginConfig.chunkFilename,
   withExtension = false
 ): string => {

--- a/src/helpers/getNameFromAsset.ts
+++ b/src/helpers/getNameFromAsset.ts
@@ -3,11 +3,11 @@
  * See LICENSE.md in the project root for license information.
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import { escapeRegExp } from 'lodash';
 import { defaultBasePluginConfig } from '../config/PluginConfig';
 
-export const Asset = ({ assets: [{}] } as webpack.Stats.ToJsonOutput).assets[0];
+export const Asset = ({ assets: [{}] } as webpack4.Stats.ToJsonOutput).assets[0];
 
 const getNameFromAsset = (
   asset: typeof Asset,

--- a/src/helpers/getNameFromAsset.ts
+++ b/src/helpers/getNameFromAsset.ts
@@ -4,7 +4,7 @@
  */
 import { escapeRegExp } from 'lodash';
 import { defaultBasePluginConfig } from '../config/PluginConfig';
-import { Asset } from './constants';
+import { Asset } from '../types';
 
 const getNameFromAsset = (
   asset: Asset,

--- a/src/helpers/mapChunkNamesExtensionsToSize.test.ts
+++ b/src/helpers/mapChunkNamesExtensionsToSize.test.ts
@@ -4,14 +4,14 @@
  */
 import { defaultBasePluginConfig } from '../config/PluginConfig';
 import { Stats4, Stats5 } from '../types';
-import extractStats from './extractStats';
+import normalizeStats from './normalizeStats';
 
 import mapChunkNamesExtensionsToSize from './mapChunkNamesExtensionsToSize';
 
 describe('mapChunkNamesExtensionsToSize', () => {
   describe('webpack v5', () => {
     it('maps js/css/mjs (but not the .map files)', () => {
-      const extractedStats = extractStats({
+      const normalizedStats = normalizeStats({
         assets: [
           {
             type: 'asset',
@@ -208,7 +208,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
       } as Stats5);
 
       expect(
-        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+        mapChunkNamesExtensionsToSize(normalizedStats, defaultBasePluginConfig.chunkFilename)
       ).toEqual({
         sgpTrainTimesPage: {
           css: {
@@ -226,7 +226,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
     });
 
     it('returns null when brolti is not defined', () => {
-      const extractedStats = extractStats({
+      const normalizedStats = normalizeStats({
         assets: [
           {
             type: 'asset',
@@ -258,13 +258,13 @@ describe('mapChunkNamesExtensionsToSize', () => {
       } as Stats5);
 
       expect(
-        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+        mapChunkNamesExtensionsToSize(normalizedStats, defaultBasePluginConfig.chunkFilename)
           .sgpTrainTimesPage.js
       ).toHaveProperty('brSize', null);
     });
 
     it('returns null when gzip is not defined', () => {
-      const extractedStats = extractStats({
+      const normalizedStats = normalizeStats({
         assets: [
           {
             type: 'asset',
@@ -299,13 +299,13 @@ describe('mapChunkNamesExtensionsToSize', () => {
       } as Stats5);
 
       expect(
-        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+        mapChunkNamesExtensionsToSize(normalizedStats, defaultBasePluginConfig.chunkFilename)
           .sgpTrainTimesPage.js
       ).toHaveProperty('gzSize', null);
     });
 
     it('does not map image', () => {
-      const extractedStats = extractStats({
+      const normalizedStats = normalizeStats({
         assets: [
           {
             type: 'asset',
@@ -328,14 +328,14 @@ describe('mapChunkNamesExtensionsToSize', () => {
       } as Stats5);
 
       expect(
-        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+        mapChunkNamesExtensionsToSize(normalizedStats, defaultBasePluginConfig.chunkFilename)
       ).toEqual({});
     });
   });
 
   describe('webpack v4', () => {
     it('maps js/css/mjs (but not the .map files)', () => {
-      const extractedStats = extractStats({
+      const normalizedStats = normalizeStats({
         _showErrors: false,
         _showWarnings: false,
         errors: [],
@@ -401,7 +401,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
       } as Stats4);
 
       expect(
-        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+        mapChunkNamesExtensionsToSize(normalizedStats, defaultBasePluginConfig.chunkFilename)
       ).toEqual({
         sgpTrainTimesPage: {
           css: {
@@ -419,7 +419,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
     });
 
     it('returns null when brolti is not defined', () => {
-      const extractedStats = extractStats({
+      const normalizedStats = normalizeStats({
         _showErrors: false,
         _showWarnings: false,
         errors: [],
@@ -436,13 +436,13 @@ describe('mapChunkNamesExtensionsToSize', () => {
       } as Stats4);
 
       expect(
-        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+        mapChunkNamesExtensionsToSize(normalizedStats, defaultBasePluginConfig.chunkFilename)
           .sgpTrainTimesPage.js
       ).toHaveProperty('brSize', null);
     });
 
     it('returns null when gzip is not defined', () => {
-      const extractedStats = extractStats({
+      const normalizedStats = normalizeStats({
         _showErrors: false,
         _showWarnings: false,
         errors: [],
@@ -459,13 +459,13 @@ describe('mapChunkNamesExtensionsToSize', () => {
       } as Stats4);
 
       expect(
-        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+        mapChunkNamesExtensionsToSize(normalizedStats, defaultBasePluginConfig.chunkFilename)
           .sgpTrainTimesPage.js
       ).toHaveProperty('gzSize', null);
     });
 
     it('does not map image', () => {
-      const extractedStats = extractStats({
+      const normalizedStats = normalizeStats({
         _showErrors: false,
         _showWarnings: false,
         errors: [],
@@ -482,7 +482,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
       } as Stats4);
 
       expect(
-        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+        mapChunkNamesExtensionsToSize(normalizedStats, defaultBasePluginConfig.chunkFilename)
       ).toEqual({});
     });
   });

--- a/src/helpers/mapChunkNamesExtensionsToSize.test.ts
+++ b/src/helpers/mapChunkNamesExtensionsToSize.test.ts
@@ -2,14 +2,14 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import { defaultBasePluginConfig } from '../config/PluginConfig';
 
 import mapChunkNamesExtensionsToSize from './mapChunkNamesExtensionsToSize';
 
 describe('mapChunkNamesExtensionsToSize', () => {
   it('maps js/css/mjs (but not the .map files)', () => {
-    const stats: webpack.Stats.ToJsonOutput = {
+    const stats: webpack4.Stats.ToJsonOutput = {
       _showErrors: false,
       _showWarnings: false,
       errors: [],
@@ -91,7 +91,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
   });
 
   it('returns null when brolti is not defined', () => {
-    const stats: webpack.Stats.ToJsonOutput = {
+    const stats: webpack4.Stats.ToJsonOutput = {
       _showErrors: false,
       _showWarnings: false,
       errors: [],
@@ -114,7 +114,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
   });
 
   it('returns null when gzip is not defined', () => {
-    const stats: webpack.Stats.ToJsonOutput = {
+    const stats: webpack4.Stats.ToJsonOutput = {
       _showErrors: false,
       _showWarnings: false,
       errors: [],
@@ -137,7 +137,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
   });
 
   it('does not map image', () => {
-    const stats: webpack.Stats.ToJsonOutput = {
+    const stats: webpack4.Stats.ToJsonOutput = {
       _showErrors: false,
       _showWarnings: false,
       errors: [],

--- a/src/helpers/mapChunkNamesExtensionsToSize.test.ts
+++ b/src/helpers/mapChunkNamesExtensionsToSize.test.ts
@@ -3,156 +3,487 @@
  * See LICENSE.md in the project root for license information.
  */
 import { defaultBasePluginConfig } from '../config/PluginConfig';
-import { Stats4 } from './constants';
+import { Stats4, Stats5 } from './constants';
+import extractStats from './extractStats';
 
 import mapChunkNamesExtensionsToSize from './mapChunkNamesExtensionsToSize';
 
 describe('mapChunkNamesExtensionsToSize', () => {
-  it('maps js/css/mjs (but not the .map files)', () => {
-    const stats: Stats4 = {
-      _showErrors: false,
-      _showWarnings: false,
-      errors: [],
-      warnings: [],
-      assets: [
-        {
-          name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js',
-          size: 653190,
-          chunks: [61],
-          chunkNames: ['sgpTrainTimesPage'],
-          emitted: true,
-        },
-        {
-          name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js.br',
-          size: 134674,
-          chunks: [],
-          chunkNames: [],
-          emitted: true,
-        },
-        {
-          name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js.gz',
-          size: 174867,
-          chunks: [],
-          chunkNames: [],
-          emitted: true,
-        },
-        {
-          name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js.map',
-          size: 1994525,
-          chunks: [61],
-          chunkNames: ['sgpTrainTimesPage'],
-          emitted: true,
-        },
-        {
-          name: 'sgpTrainTimesPage.f8f2d0c60ba75f897b63.css',
-          size: 296997,
-          chunks: [61],
-          chunkNames: ['sgpTrainTimesPage'],
-          emitted: true,
-        },
-        {
-          name: 'sgpTrainTimesPage.f8f2d0c60ba75f897b63.css.br',
-          size: 37028,
-          chunks: [],
-          chunkNames: [],
-          emitted: true,
-        },
-        {
-          name: 'sgpTrainTimesPage.f8f2d0c60ba75f897b63.css.gz',
-          size: 45562,
-          chunks: [],
-          chunkNames: [],
-          emitted: true,
-        },
-        {
-          name: 'sgpTrainTimesPage.f8f2d0c60ba75f897b63.css.map',
-          size: 354867,
-          chunks: [61],
-          chunkNames: ['sgpTrainTimesPage'],
-          emitted: true,
-        },
-      ],
-    };
+  describe('webpack v5', () => {
+    it('maps js/css/mjs (but not the .map files)', () => {
+      const extractedStats = extractStats({
+        assets: [
+          {
+            type: 'asset',
+            name: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js',
+            size: 697628,
+            chunkNames: ['sgpTrainTimesPage'],
+            chunkIdHints: [],
+            auxiliaryChunkNames: [],
+            auxiliaryChunkIdHints: [],
+            emitted: false,
+            comparedForEmit: false,
+            cached: true,
+            info: {
+              immutable: true,
+              contenthash: '5fd3bc7f80aa9a623024',
+              javascriptModule: false,
+              minimized: true,
+              related: {
+                license: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.LICENSE.txt',
+                sourceMap: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.map',
+                gzipped: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.gz',
+                brotliCompressed: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.br',
+              },
+            },
+            filteredRelated: 0,
+            related: [
+              {
+                type: 'sourceMap',
+                name: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.map',
+                size: 2006828,
+                chunkNames: [],
+                chunkIdHints: [],
+                auxiliaryChunkNames: ['sgpTrainTimesPage'],
+                auxiliaryChunkIdHints: [],
+                emitted: false,
+                comparedForEmit: false,
+                cached: true,
+                info: {
+                  development: true,
+                },
+                chunks: [],
+                auxiliaryChunks: [9789],
+                isOverSizeLimit: false,
+              },
+              {
+                type: 'gzipped',
+                name: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.gz',
+                size: 175985,
+                chunkNames: [],
+                chunkIdHints: [],
+                auxiliaryChunkNames: [],
+                auxiliaryChunkIdHints: [],
+                emitted: false,
+                comparedForEmit: false,
+                cached: true,
+                info: {
+                  compressed: true,
+                  immutable: true,
+                },
+                related: {},
+                chunks: [],
+                auxiliaryChunks: [],
+                isOverSizeLimit: false,
+              },
+              {
+                type: 'brotliCompressed',
+                name: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.br',
+                size: 140119,
+                chunkNames: [],
+                chunkIdHints: [],
+                auxiliaryChunkNames: [],
+                auxiliaryChunkIdHints: [],
+                emitted: false,
+                comparedForEmit: false,
+                cached: true,
+                info: {
+                  compressed: true,
+                  immutable: true,
+                },
+                related: {},
+                chunks: [],
+                auxiliaryChunks: [],
+                isOverSizeLimit: false,
+              },
+              {
+                type: 'license',
+                name: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.LICENSE.txt',
+                size: 1201,
+                chunkNames: [],
+                chunkIdHints: [],
+                auxiliaryChunkNames: [],
+                auxiliaryChunkIdHints: [],
+                emitted: false,
+                comparedForEmit: false,
+                cached: true,
+                info: {},
+                related: {},
+                chunks: [],
+                auxiliaryChunks: [],
+                isOverSizeLimit: false,
+              },
+            ],
+            chunks: [9789],
+            auxiliaryChunks: [],
+            isOverSizeLimit: false,
+          },
+          {
+            type: 'asset',
+            name: 'sgpTrainTimesPage.b0c58d10bba703efd363.css',
+            size: 295788,
+            chunkNames: ['sgpTrainTimesPage'],
+            chunkIdHints: [],
+            auxiliaryChunkNames: [],
+            auxiliaryChunkIdHints: [],
+            emitted: false,
+            comparedForEmit: false,
+            cached: true,
+            info: {
+              immutable: true,
+              contenthash: 'b0c58d10bba703efd363',
+              related: {
+                sourceMap: 'sgpTrainTimesPage.b0c58d10bba703efd363.css.map',
+                gzipped: 'sgpTrainTimesPage.b0c58d10bba703efd363.css.gz',
+                brotliCompressed: 'sgpTrainTimesPage.b0c58d10bba703efd363.css.br',
+              },
+            },
+            filteredRelated: 0,
+            related: [
+              {
+                type: 'sourceMap',
+                name: 'sgpTrainTimesPage.b0c58d10bba703efd363.css.map',
+                size: 437990,
+                chunkNames: [],
+                chunkIdHints: [],
+                auxiliaryChunkNames: ['sgpTrainTimesPage'],
+                auxiliaryChunkIdHints: [],
+                emitted: false,
+                comparedForEmit: false,
+                cached: true,
+                info: {
+                  development: true,
+                },
+                related: {},
+                chunks: [],
+                auxiliaryChunks: [9789],
+                isOverSizeLimit: false,
+              },
+              {
+                type: 'gzipped',
+                name: 'sgpTrainTimesPage.b0c58d10bba703efd363.css.gz',
+                size: 45646,
+                chunkNames: [],
+                chunkIdHints: [],
+                auxiliaryChunkNames: [],
+                auxiliaryChunkIdHints: [],
+                emitted: false,
+                comparedForEmit: false,
+                cached: true,
+                info: {
+                  compressed: true,
+                  immutable: true,
+                },
+                related: {},
+                chunks: [],
+                auxiliaryChunks: [],
+                isOverSizeLimit: false,
+              },
+              {
+                type: 'brotliCompressed',
+                name: 'sgpTrainTimesPage.b0c58d10bba703efd363.css.br',
+                size: 37267,
+                chunkNames: [],
+                chunkIdHints: [],
+                auxiliaryChunkNames: [],
+                auxiliaryChunkIdHints: [],
+                emitted: false,
+                comparedForEmit: false,
+                cached: true,
+                info: {
+                  compressed: true,
+                  immutable: true,
+                },
+                related: {},
+                chunks: [],
+                auxiliaryChunks: [],
+                isOverSizeLimit: false,
+              },
+            ],
+            chunks: [9789],
+            auxiliaryChunks: [],
+            isOverSizeLimit: false,
+          },
+        ],
+      } as Stats5);
 
-    expect(mapChunkNamesExtensionsToSize(stats, defaultBasePluginConfig.chunkFilename)).toEqual({
-      sgpTrainTimesPage: {
-        css: {
-          brSize: 37028,
-          gzSize: 45562,
-          size: 296997,
+      expect(
+        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+      ).toEqual({
+        sgpTrainTimesPage: {
+          css: {
+            brSize: 37267,
+            gzSize: 45646,
+            size: 295788,
+          },
+          js: {
+            brSize: 140119,
+            gzSize: 175985,
+            size: 697628,
+          },
         },
-        js: {
-          brSize: 134674,
-          gzSize: 174867,
-          size: 653190,
-        },
-      },
+      });
+    });
+
+    it('returns null when brolti is not defined', () => {
+      const extractedStats = extractStats({
+        assets: [
+          {
+            type: 'asset',
+            name: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js',
+            size: 697628,
+            chunkNames: ['sgpTrainTimesPage'],
+            chunkIdHints: [],
+            auxiliaryChunkNames: [],
+            auxiliaryChunkIdHints: [],
+            emitted: false,
+            comparedForEmit: false,
+            cached: true,
+            info: {
+              immutable: true,
+              contenthash: '5fd3bc7f80aa9a623024',
+              javascriptModule: false,
+              minimized: true,
+              related: {
+                gzipped: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.gz',
+              },
+            },
+            filteredRelated: 0,
+            related: [],
+            chunks: [9789],
+            auxiliaryChunks: [],
+            isOverSizeLimit: false,
+          },
+        ],
+      } as Stats5);
+
+      expect(
+        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+          .sgpTrainTimesPage.js
+      ).toHaveProperty('brSize', null);
+    });
+
+    it('returns null when gzip is not defined', () => {
+      const extractedStats = extractStats({
+        assets: [
+          {
+            type: 'asset',
+            name: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js',
+            size: 697628,
+            chunkNames: ['sgpTrainTimesPage'],
+            chunkIdHints: [],
+            auxiliaryChunkNames: [],
+            auxiliaryChunkIdHints: [],
+            emitted: false,
+            comparedForEmit: false,
+            cached: true,
+            info: {
+              immutable: true,
+              contenthash: '5fd3bc7f80aa9a623024',
+              javascriptModule: false,
+              minimized: true,
+              related: {
+                license: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.LICENSE.txt',
+                sourceMap: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.map',
+                gzipped: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.gz',
+                brotliCompressed: 'sgpTrainTimesPage-5fd3bc7f80aa9a623024.js.br',
+              },
+            },
+            filteredRelated: 0,
+            related: [],
+            chunks: [9789],
+            auxiliaryChunks: [],
+            isOverSizeLimit: false,
+          },
+        ],
+      } as Stats5);
+
+      expect(
+        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+          .sgpTrainTimesPage.js
+      ).toHaveProperty('gzSize', null);
+    });
+
+    it('does not map image', () => {
+      const extractedStats = extractStats({
+        assets: [
+          {
+            type: 'asset',
+            name: '537a564a96318309f3b965b7dc553e33.jpg',
+            size: 175731,
+            chunkNames: [],
+            chunkIdHints: [],
+            auxiliaryChunkNames: ['backgrounds'],
+            auxiliaryChunkIdHints: [],
+            emitted: false,
+            comparedForEmit: false,
+            cached: true,
+            info: {},
+            related: {},
+            chunks: [],
+            auxiliaryChunks: [4231],
+            isOverSizeLimit: false,
+          },
+        ],
+      } as Stats5);
+
+      expect(
+        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+      ).toEqual({});
     });
   });
 
-  it('returns null when brolti is not defined', () => {
-    const stats: Stats4 = {
-      _showErrors: false,
-      _showWarnings: false,
-      errors: [],
-      warnings: [],
-      assets: [
-        {
-          name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js',
-          size: 653190,
-          chunks: [61],
-          chunkNames: ['sgpTrainTimesPage'],
-          emitted: true,
+  describe('webpack v4', () => {
+    it('maps js/css/mjs (but not the .map files)', () => {
+      const extractedStats = extractStats({
+        _showErrors: false,
+        _showWarnings: false,
+        errors: [],
+        warnings: [],
+        assets: [
+          {
+            name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js',
+            size: 653190,
+            chunks: [61],
+            chunkNames: ['sgpTrainTimesPage'],
+            emitted: true,
+          },
+          {
+            name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js.br',
+            size: 134674,
+            chunks: [],
+            chunkNames: [],
+            emitted: true,
+          },
+          {
+            name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js.gz',
+            size: 174867,
+            chunks: [],
+            chunkNames: [],
+            emitted: true,
+          },
+          {
+            name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js.map',
+            size: 1994525,
+            chunks: [61],
+            chunkNames: ['sgpTrainTimesPage'],
+            emitted: true,
+          },
+          {
+            name: 'sgpTrainTimesPage.f8f2d0c60ba75f897b63.css',
+            size: 296997,
+            chunks: [61],
+            chunkNames: ['sgpTrainTimesPage'],
+            emitted: true,
+          },
+          {
+            name: 'sgpTrainTimesPage.f8f2d0c60ba75f897b63.css.br',
+            size: 37028,
+            chunks: [],
+            chunkNames: [],
+            emitted: true,
+          },
+          {
+            name: 'sgpTrainTimesPage.f8f2d0c60ba75f897b63.css.gz',
+            size: 45562,
+            chunks: [],
+            chunkNames: [],
+            emitted: true,
+          },
+          {
+            name: 'sgpTrainTimesPage.f8f2d0c60ba75f897b63.css.map',
+            size: 354867,
+            chunks: [61],
+            chunkNames: ['sgpTrainTimesPage'],
+            emitted: true,
+          },
+        ],
+      } as Stats4);
+
+      expect(
+        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+      ).toEqual({
+        sgpTrainTimesPage: {
+          css: {
+            brSize: 37028,
+            gzSize: 45562,
+            size: 296997,
+          },
+          js: {
+            brSize: 134674,
+            gzSize: 174867,
+            size: 653190,
+          },
         },
-      ],
-    };
+      });
+    });
 
-    expect(
-      mapChunkNamesExtensionsToSize(stats, defaultBasePluginConfig.chunkFilename).sgpTrainTimesPage
-        .js
-    ).toHaveProperty('brSize', null);
-  });
+    it('returns null when brolti is not defined', () => {
+      const extractedStats = extractStats({
+        _showErrors: false,
+        _showWarnings: false,
+        errors: [],
+        warnings: [],
+        assets: [
+          {
+            name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js',
+            size: 653190,
+            chunks: [61],
+            chunkNames: ['sgpTrainTimesPage'],
+            emitted: true,
+          },
+        ],
+      } as Stats4);
 
-  it('returns null when gzip is not defined', () => {
-    const stats: Stats4 = {
-      _showErrors: false,
-      _showWarnings: false,
-      errors: [],
-      warnings: [],
-      assets: [
-        {
-          name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js',
-          size: 653190,
-          chunks: [61],
-          chunkNames: ['sgpTrainTimesPage'],
-          emitted: true,
-        },
-      ],
-    };
+      expect(
+        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+          .sgpTrainTimesPage.js
+      ).toHaveProperty('brSize', null);
+    });
 
-    expect(
-      mapChunkNamesExtensionsToSize(stats, defaultBasePluginConfig.chunkFilename).sgpTrainTimesPage
-        .js
-    ).toHaveProperty('gzSize', null);
-  });
+    it('returns null when gzip is not defined', () => {
+      const extractedStats = extractStats({
+        _showErrors: false,
+        _showWarnings: false,
+        errors: [],
+        warnings: [],
+        assets: [
+          {
+            name: 'sgpTrainTimesPage-784f294928e1a77ed6c4.js',
+            size: 653190,
+            chunks: [61],
+            chunkNames: ['sgpTrainTimesPage'],
+            emitted: true,
+          },
+        ],
+      } as Stats4);
 
-  it('does not map image', () => {
-    const stats: Stats4 = {
-      _showErrors: false,
-      _showWarnings: false,
-      errors: [],
-      warnings: [],
-      assets: [
-        {
-          name: '3b1c17aaa00d5f277227fae592484408.jpg',
-          size: 9705,
-          chunks: [],
-          chunkNames: [],
-          emitted: true,
-        },
-      ],
-    };
+      expect(
+        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+          .sgpTrainTimesPage.js
+      ).toHaveProperty('gzSize', null);
+    });
 
-    expect(mapChunkNamesExtensionsToSize(stats, defaultBasePluginConfig.chunkFilename)).toEqual({});
+    it('does not map image', () => {
+      const extractedStats = extractStats({
+        _showErrors: false,
+        _showWarnings: false,
+        errors: [],
+        warnings: [],
+        assets: [
+          {
+            name: '3b1c17aaa00d5f277227fae592484408.jpg',
+            size: 9705,
+            chunks: [],
+            chunkNames: [],
+            emitted: true,
+          },
+        ],
+      } as Stats4);
+
+      expect(
+        mapChunkNamesExtensionsToSize(extractedStats, defaultBasePluginConfig.chunkFilename)
+      ).toEqual({});
+    });
   });
 });

--- a/src/helpers/mapChunkNamesExtensionsToSize.test.ts
+++ b/src/helpers/mapChunkNamesExtensionsToSize.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license information.
  */
 import { defaultBasePluginConfig } from '../config/PluginConfig';
-import { Stats4, Stats5 } from './constants';
+import { Stats4, Stats5 } from '../types';
 import extractStats from './extractStats';
 
 import mapChunkNamesExtensionsToSize from './mapChunkNamesExtensionsToSize';

--- a/src/helpers/mapChunkNamesExtensionsToSize.test.ts
+++ b/src/helpers/mapChunkNamesExtensionsToSize.test.ts
@@ -2,14 +2,14 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack4 from 'webpack4';
 import { defaultBasePluginConfig } from '../config/PluginConfig';
+import { Stats4 } from './constants';
 
 import mapChunkNamesExtensionsToSize from './mapChunkNamesExtensionsToSize';
 
 describe('mapChunkNamesExtensionsToSize', () => {
   it('maps js/css/mjs (but not the .map files)', () => {
-    const stats: webpack4.Stats.ToJsonOutput = {
+    const stats: Stats4 = {
       _showErrors: false,
       _showWarnings: false,
       errors: [],
@@ -91,7 +91,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
   });
 
   it('returns null when brolti is not defined', () => {
-    const stats: webpack4.Stats.ToJsonOutput = {
+    const stats: Stats4 = {
       _showErrors: false,
       _showWarnings: false,
       errors: [],
@@ -114,7 +114,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
   });
 
   it('returns null when gzip is not defined', () => {
-    const stats: webpack4.Stats.ToJsonOutput = {
+    const stats: Stats4 = {
       _showErrors: false,
       _showWarnings: false,
       errors: [],
@@ -137,7 +137,7 @@ describe('mapChunkNamesExtensionsToSize', () => {
   });
 
   it('does not map image', () => {
-    const stats: webpack4.Stats.ToJsonOutput = {
+    const stats: Stats4 = {
       _showErrors: false,
       _showWarnings: false,
       errors: [],

--- a/src/helpers/mapChunkNamesExtensionsToSize.ts
+++ b/src/helpers/mapChunkNamesExtensionsToSize.ts
@@ -8,9 +8,8 @@ import {
   FILENAME_QUERY_REGEXP,
   SupportedExtensions,
 } from './constants';
-import { ExtractedStats } from './extractStats';
 import getNameFromAsset from './getNameFromAsset';
-import { Asset, Asset4, Asset5, Stats } from '../types';
+import { Asset, Asset4, Asset5, NormalizedStats, Stats } from '../types';
 
 export interface ChunkNamesExtensionsToSize {
   [chunkName: string]: {
@@ -23,10 +22,10 @@ export interface ChunkNamesExtensionsToSize {
 }
 
 const mapChunkNamesExtensionsToSize = (
-  extractedStats: ExtractedStats,
+  normalizedStats: NormalizedStats,
   chunkFilename: string
 ): ChunkNamesExtensionsToSize => {
-  return (extractedStats.stats as Stats[]).reduce((chunkNamesExtensionsToSize, stats) => {
+  return (normalizedStats.stats as Stats[]).reduce((chunkNamesExtensionsToSize, stats) => {
     const { assets } = stats;
     (assets as Asset[])
       .filter((asset) =>
@@ -40,7 +39,7 @@ const mapChunkNamesExtensionsToSize = (
         // these are only generated when the ratio is high enough
         let gzAsset: Asset;
         let brAsset: Asset;
-        if (extractedStats.majorVersion === 4) {
+        if (normalizedStats.majorVersion === 4) {
           const assets4 = assets as Asset4[];
           gzAsset = assets4.find((a) => a.name.startsWith(`${nameWithoutQuery}.gz`));
           brAsset = assets4.find((a) => a.name.startsWith(`${nameWithoutQuery}.br`));

--- a/src/helpers/mapChunkNamesExtensionsToSize.ts
+++ b/src/helpers/mapChunkNamesExtensionsToSize.ts
@@ -4,16 +4,13 @@
  */
 
 import {
-  Asset,
-  Asset4,
-  Asset5,
   FILENAME_JS_MJS_CSS_EXTENSIONS,
   FILENAME_QUERY_REGEXP,
-  Stats,
   SupportedExtensions,
 } from './constants';
 import { ExtractedStats } from './extractStats';
 import getNameFromAsset from './getNameFromAsset';
+import { Asset, Asset4, Asset5, Stats } from '../types';
 
 export interface ChunkNamesExtensionsToSize {
   [chunkName: string]: {

--- a/src/helpers/mapChunkNamesExtensionsToSize.ts
+++ b/src/helpers/mapChunkNamesExtensionsToSize.ts
@@ -3,14 +3,13 @@
  * See LICENSE.md in the project root for license information.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
 import {
   FILENAME_JS_MJS_CSS_EXTENSIONS,
   FILENAME_QUERY_REGEXP,
+  Stats4,
   SupportedExtensions,
 } from './constants';
-import extractStats from './extractStats';
+import extractStats, { ExtractedStats4 } from './extractStats';
 import getNameFromAsset from './getNameFromAsset';
 
 export interface ChunkNamesExtensionsToSize {
@@ -24,37 +23,40 @@ export interface ChunkNamesExtensionsToSize {
 }
 
 const mapChunkNamesExtensionsToSize = (
-  compilationStats: webpack4.Stats.ToJsonOutput,
+  compilationStats: Stats4,
   chunkFilename: string
 ): ChunkNamesExtensionsToSize => {
-  return extractStats(compilationStats).reduce((chunkNamesExtensionsToSize, stats) => {
-    const { assets } = stats;
-    assets
-      .filter((asset) =>
-        FILENAME_JS_MJS_CSS_EXTENSIONS.test(asset.name.replace(FILENAME_QUERY_REGEXP, ''))
-      )
-      .forEach((asset) => {
-        const { name, size } = asset;
-        const nameWithoutQuery = name.split('?')[0];
-        const extension = nameWithoutQuery.split('.').pop();
-        // these are only generated when the ratio is high enough
-        const gzAsset = assets.find((a) => a.name.startsWith(`${nameWithoutQuery}.gz`));
-        const brAsset = assets.find((a) => a.name.startsWith(`${nameWithoutQuery}.br`));
+  return (extractStats(compilationStats) as ExtractedStats4).stats.reduce(
+    (chunkNamesExtensionsToSize, stats) => {
+      const { assets } = stats;
+      assets
+        .filter((asset) =>
+          FILENAME_JS_MJS_CSS_EXTENSIONS.test(asset.name.replace(FILENAME_QUERY_REGEXP, ''))
+        )
+        .forEach((asset) => {
+          const { name, size } = asset;
+          const nameWithoutQuery = name.split('?')[0];
+          const extension = nameWithoutQuery.split('.').pop();
+          // these are only generated when the ratio is high enough
+          const gzAsset = assets.find((a) => a.name.startsWith(`${nameWithoutQuery}.gz`));
+          const brAsset = assets.find((a) => a.name.startsWith(`${nameWithoutQuery}.br`));
 
-        const customName = getNameFromAsset(asset, chunkFilename, false);
+          const customName = getNameFromAsset(asset, chunkFilename, false);
 
-        // eslint-disable-next-line no-param-reassign
-        chunkNamesExtensionsToSize[customName] = {
-          ...chunkNamesExtensionsToSize[customName],
-          [extension]: {
-            size,
-            gzSize: gzAsset ? gzAsset.size : null,
-            brSize: brAsset ? brAsset.size : null,
-          },
-        };
-      });
-    return chunkNamesExtensionsToSize;
-  }, {} as ChunkNamesExtensionsToSize);
+          // eslint-disable-next-line no-param-reassign
+          chunkNamesExtensionsToSize[customName] = {
+            ...chunkNamesExtensionsToSize[customName],
+            [extension]: {
+              size,
+              gzSize: gzAsset ? gzAsset.size : null,
+              brSize: brAsset ? brAsset.size : null,
+            },
+          };
+        });
+      return chunkNamesExtensionsToSize;
+    },
+    {} as ChunkNamesExtensionsToSize
+  );
 };
 
 export default mapChunkNamesExtensionsToSize;

--- a/src/helpers/mapChunkNamesExtensionsToSize.ts
+++ b/src/helpers/mapChunkNamesExtensionsToSize.ts
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import {
   FILENAME_JS_MJS_CSS_EXTENSIONS,
   FILENAME_QUERY_REGEXP,
@@ -24,7 +24,7 @@ export interface ChunkNamesExtensionsToSize {
 }
 
 const mapChunkNamesExtensionsToSize = (
-  compilationStats: webpack.Stats.ToJsonOutput,
+  compilationStats: webpack4.Stats.ToJsonOutput,
   chunkFilename: string
 ): ChunkNamesExtensionsToSize => {
   return extractStats(compilationStats).reduce((chunkNamesExtensionsToSize, stats) => {

--- a/src/helpers/mapChunkNamesWithModules.test.ts
+++ b/src/helpers/mapChunkNamesWithModules.test.ts
@@ -4,7 +4,7 @@
  */
 import mapChunkNamesWithModules from './mapChunkNamesWithModules';
 import compilationStats from '../../test/fixtures/head-compilation-stats.json';
-import { Stats4 } from './constants';
+import { Stats4 } from '../types';
 import extractStats from './extractStats';
 
 const stats = (compilationStats as unknown) as Stats4;

--- a/src/helpers/mapChunkNamesWithModules.test.ts
+++ b/src/helpers/mapChunkNamesWithModules.test.ts
@@ -2,12 +2,12 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 
 import mapChunkNamesWithModules from './mapChunkNamesWithModules';
 import compilationStats from '../../test/fixtures/head-compilation-stats.json';
 
-const stats = (compilationStats as unknown) as webpack.Stats.ToJsonOutput;
+const stats = (compilationStats as unknown) as webpack4.Stats.ToJsonOutput;
 
 describe('mapChunkNamesWithModules', () => {
   it('returns null when assets are not specified in webpack stats', () => {

--- a/src/helpers/mapChunkNamesWithModules.test.ts
+++ b/src/helpers/mapChunkNamesWithModules.test.ts
@@ -2,12 +2,11 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack4 from 'webpack4';
-
 import mapChunkNamesWithModules from './mapChunkNamesWithModules';
 import compilationStats from '../../test/fixtures/head-compilation-stats.json';
+import { Stats4 } from './constants';
 
-const stats = (compilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const stats = (compilationStats as unknown) as Stats4;
 
 describe('mapChunkNamesWithModules', () => {
   it('returns null when assets are not specified in webpack stats', () => {

--- a/src/helpers/mapChunkNamesWithModules.test.ts
+++ b/src/helpers/mapChunkNamesWithModules.test.ts
@@ -5,62 +5,65 @@
 import mapChunkNamesWithModules from './mapChunkNamesWithModules';
 import compilationStats from '../../test/fixtures/head-compilation-stats.json';
 import { Stats4 } from './constants';
+import extractStats from './extractStats';
 
 const stats = (compilationStats as unknown) as Stats4;
 
 describe('mapChunkNamesWithModules', () => {
   it('returns null when assets are not specified in webpack stats', () => {
-    expect(
-      mapChunkNamesWithModules({
-        errors: [],
-        warnings: [],
-        _showErrors: false,
-        _showWarnings: false,
-        modules: stats.modules,
-      })
-    ).toBeNull();
+    const extractedStats = extractStats({
+      errors: [],
+      warnings: [],
+      _showErrors: false,
+      _showWarnings: false,
+      modules: stats.modules,
+    });
+
+    expect(mapChunkNamesWithModules(extractedStats)).toBeNull();
   });
 
   it('returns null when assets is empty in webpack stats', () => {
-    expect(
-      mapChunkNamesWithModules({
-        errors: [],
-        warnings: [],
-        _showErrors: false,
-        _showWarnings: false,
-        assets: [],
-        modules: stats.modules,
-      })
-    ).toBeNull();
+    const extractedStats = extractStats({
+      errors: [],
+      warnings: [],
+      _showErrors: false,
+      _showWarnings: false,
+      assets: [],
+      modules: stats.modules,
+    });
+
+    expect(mapChunkNamesWithModules(extractedStats)).toBeNull();
   });
 
   it('returns null when modules are empty specified in webpack stats', () => {
-    expect(
-      mapChunkNamesWithModules({
-        errors: [],
-        warnings: [],
-        modules: [],
-        _showErrors: false,
-        _showWarnings: false,
-        assets: stats.assets,
-      })
-    ).toBeNull();
+    const extractedStats = extractStats({
+      errors: [],
+      warnings: [],
+      modules: [],
+      _showErrors: false,
+      _showWarnings: false,
+      assets: stats.assets,
+    });
+
+    expect(mapChunkNamesWithModules(extractedStats)).toBeNull();
   });
 
   it('returns null when modules is empty in webpack stats', () => {
-    expect(
-      mapChunkNamesWithModules({
-        errors: [],
-        warnings: [],
-        _showErrors: false,
-        _showWarnings: false,
-        assets: stats.assets,
-        modules: [],
-      })
-    ).toBeNull();
+    const extractedStats = extractStats({
+      errors: [],
+      warnings: [],
+      _showErrors: false,
+      _showWarnings: false,
+      assets: stats.assets,
+      modules: [],
+    });
+
+    expect(mapChunkNamesWithModules(extractedStats)).toBeNull();
   });
 
   it('builds the dependency tree', () => {
-    expect(mapChunkNamesWithModules(stats)).toMatchSnapshot();
+    const extractedStats = extractStats(stats);
+
+    expect(mapChunkNamesWithModules(extractedStats)).toMatchSnapshot();
   });
 });

--- a/src/helpers/mapChunkNamesWithModules.test.ts
+++ b/src/helpers/mapChunkNamesWithModules.test.ts
@@ -5,13 +5,13 @@
 import mapChunkNamesWithModules from './mapChunkNamesWithModules';
 import compilationStats from '../../test/fixtures/head-compilation-stats.json';
 import { Stats4 } from '../types';
-import extractStats from './extractStats';
+import normalizeStats from './normalizeStats';
 
 const stats = (compilationStats as unknown) as Stats4;
 
 describe('mapChunkNamesWithModules', () => {
   it('returns null when assets are not specified in webpack stats', () => {
-    const extractedStats = extractStats({
+    const normalizedStats = normalizeStats({
       errors: [],
       warnings: [],
       _showErrors: false,
@@ -19,11 +19,11 @@ describe('mapChunkNamesWithModules', () => {
       modules: stats.modules,
     });
 
-    expect(mapChunkNamesWithModules(extractedStats)).toBeNull();
+    expect(mapChunkNamesWithModules(normalizedStats)).toBeNull();
   });
 
   it('returns null when assets is empty in webpack stats', () => {
-    const extractedStats = extractStats({
+    const normalizedStats = normalizeStats({
       errors: [],
       warnings: [],
       _showErrors: false,
@@ -32,11 +32,11 @@ describe('mapChunkNamesWithModules', () => {
       modules: stats.modules,
     });
 
-    expect(mapChunkNamesWithModules(extractedStats)).toBeNull();
+    expect(mapChunkNamesWithModules(normalizedStats)).toBeNull();
   });
 
   it('returns null when modules are empty specified in webpack stats', () => {
-    const extractedStats = extractStats({
+    const normalizedStats = normalizeStats({
       errors: [],
       warnings: [],
       modules: [],
@@ -45,11 +45,11 @@ describe('mapChunkNamesWithModules', () => {
       assets: stats.assets,
     });
 
-    expect(mapChunkNamesWithModules(extractedStats)).toBeNull();
+    expect(mapChunkNamesWithModules(normalizedStats)).toBeNull();
   });
 
   it('returns null when modules is empty in webpack stats', () => {
-    const extractedStats = extractStats({
+    const normalizedStats = normalizeStats({
       errors: [],
       warnings: [],
       _showErrors: false,
@@ -58,12 +58,12 @@ describe('mapChunkNamesWithModules', () => {
       modules: [],
     });
 
-    expect(mapChunkNamesWithModules(extractedStats)).toBeNull();
+    expect(mapChunkNamesWithModules(normalizedStats)).toBeNull();
   });
 
   it('builds the dependency tree', () => {
-    const extractedStats = extractStats(stats);
+    const normalizedStats = normalizeStats(stats);
 
-    expect(mapChunkNamesWithModules(extractedStats)).toMatchSnapshot();
+    expect(mapChunkNamesWithModules(normalizedStats)).toMatchSnapshot();
   });
 });

--- a/src/helpers/mapChunkNamesWithModules.ts
+++ b/src/helpers/mapChunkNamesWithModules.ts
@@ -3,8 +3,14 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import { FILENAME_JS_MJS_EXTENSIONS, FILENAME_QUERY_REGEXP, Stats4 } from './constants';
-import extractStats, { ExtractedStats4 } from './extractStats';
+import {
+  Asset,
+  FILENAME_JS_MJS_EXTENSIONS,
+  FILENAME_QUERY_REGEXP,
+  Module,
+  Stats,
+} from './constants';
+import { ExtractedStats } from './extractStats';
 
 export interface ChunkModule {
   file: string;
@@ -16,19 +22,20 @@ export interface ChunkNamesToModules {
   [assetName: string]: ChunkModule[];
 }
 
-const mapChunkNamesWithModules = (compilationStats: Stats4): ChunkNamesToModules => {
-  const mapped = (extractStats(compilationStats) as ExtractedStats4).stats.reduce(
-    (chunkNamesToModules, stats) => {
+const mapChunkNamesWithModules = (extractedStats: ExtractedStats): ChunkNamesToModules => {
+  const mapped = (extractedStats.stats as Stats[]).reduce(
+    (chunkNamesToModules: ChunkNamesToModules, stats: Stats) => {
       const { assets, modules } = stats;
       if (!assets || !assets.length || !modules || !modules.length) {
         return chunkNamesToModules;
       }
-      assets
+
+      (assets as Asset[])
         .filter((asset) =>
           FILENAME_JS_MJS_EXTENSIONS.test(asset.name.replace(FILENAME_QUERY_REGEXP, ''))
         )
-        .forEach((asset) => {
-          const assetModules = modules
+        .forEach((asset: Asset) => {
+          const assetModules = (modules as Module[])
             .filter((module) => module.chunks.some((chunk) => asset.chunks.includes(chunk)))
             .map((module) => {
               const [file, moduleCountText] = module.name.split(' + ');

--- a/src/helpers/mapChunkNamesWithModules.ts
+++ b/src/helpers/mapChunkNamesWithModules.ts
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import { FILENAME_JS_MJS_EXTENSIONS, FILENAME_QUERY_REGEXP } from './constants';
 import extractStats from './extractStats';
 
@@ -19,7 +19,7 @@ export interface ChunkNamesToModules {
 }
 
 const mapChunkNamesWithModules = (
-  compilationStats: webpack.Stats.ToJsonOutput
+  compilationStats: webpack4.Stats.ToJsonOutput
 ): ChunkNamesToModules => {
   const mapped = extractStats(compilationStats).reduce((chunkNamesToModules, stats) => {
     const { assets, modules } = stats;

--- a/src/helpers/mapChunkNamesWithModules.ts
+++ b/src/helpers/mapChunkNamesWithModules.ts
@@ -4,8 +4,7 @@
  */
 
 import { FILENAME_JS_MJS_EXTENSIONS, FILENAME_QUERY_REGEXP } from './constants';
-import { Asset, Module, Stats } from '../types';
-import { ExtractedStats } from './extractStats';
+import { Asset, NormalizedStats, Module, Stats } from '../types';
 
 export interface ChunkModule {
   file: string;
@@ -17,8 +16,8 @@ export interface ChunkNamesToModules {
   [assetName: string]: ChunkModule[];
 }
 
-const mapChunkNamesWithModules = (extractedStats: ExtractedStats): ChunkNamesToModules => {
-  const mapped = (extractedStats.stats as Stats[]).reduce(
+const mapChunkNamesWithModules = (normalizedStats: NormalizedStats): ChunkNamesToModules => {
+  const mapped = (normalizedStats.stats as Stats[]).reduce(
     (chunkNamesToModules: ChunkNamesToModules, stats: Stats) => {
       const { assets, modules } = stats;
       if (!assets || !assets.length || !modules || !modules.length) {

--- a/src/helpers/mapChunkNamesWithModules.ts
+++ b/src/helpers/mapChunkNamesWithModules.ts
@@ -3,10 +3,8 @@
  * See LICENSE.md in the project root for license information.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
-import { FILENAME_JS_MJS_EXTENSIONS, FILENAME_QUERY_REGEXP } from './constants';
-import extractStats from './extractStats';
+import { FILENAME_JS_MJS_EXTENSIONS, FILENAME_QUERY_REGEXP, Stats4 } from './constants';
+import extractStats, { ExtractedStats4 } from './extractStats';
 
 export interface ChunkModule {
   file: string;
@@ -18,50 +16,51 @@ export interface ChunkNamesToModules {
   [assetName: string]: ChunkModule[];
 }
 
-const mapChunkNamesWithModules = (
-  compilationStats: webpack4.Stats.ToJsonOutput
-): ChunkNamesToModules => {
-  const mapped = extractStats(compilationStats).reduce((chunkNamesToModules, stats) => {
-    const { assets, modules } = stats;
-    if (!assets || !assets.length || !modules || !modules.length) {
-      return chunkNamesToModules;
-    }
-    assets
-      .filter((asset) =>
-        FILENAME_JS_MJS_EXTENSIONS.test(asset.name.replace(FILENAME_QUERY_REGEXP, ''))
-      )
-      .forEach((asset) => {
-        const assetModules = modules
-          .filter((module) => module.chunks.some((chunk) => asset.chunks.includes(chunk)))
-          .map((module) => {
-            const [file, moduleCountText] = module.name.split(' + ');
-            const moduleCount = moduleCountText ? parseInt(moduleCountText.split(' ')[0], 10) : 0;
-            return {
-              file,
-              size: module.size,
-              moduleCount,
-            } as ChunkModule;
-          })
-          .sort((a, b) => {
-            if (a.size > b.size) {
-              return -1;
-            }
-            if (a.size < b.size) {
+const mapChunkNamesWithModules = (compilationStats: Stats4): ChunkNamesToModules => {
+  const mapped = (extractStats(compilationStats) as ExtractedStats4).stats.reduce(
+    (chunkNamesToModules, stats) => {
+      const { assets, modules } = stats;
+      if (!assets || !assets.length || !modules || !modules.length) {
+        return chunkNamesToModules;
+      }
+      assets
+        .filter((asset) =>
+          FILENAME_JS_MJS_EXTENSIONS.test(asset.name.replace(FILENAME_QUERY_REGEXP, ''))
+        )
+        .forEach((asset) => {
+          const assetModules = modules
+            .filter((module) => module.chunks.some((chunk) => asset.chunks.includes(chunk)))
+            .map((module) => {
+              const [file, moduleCountText] = module.name.split(' + ');
+              const moduleCount = moduleCountText ? parseInt(moduleCountText.split(' ')[0], 10) : 0;
+              return {
+                file,
+                size: module.size,
+                moduleCount,
+              } as ChunkModule;
+            })
+            .sort((a, b) => {
+              if (a.size > b.size) {
+                return -1;
+              }
+              if (a.size < b.size) {
+                return 1;
+              }
+              if (a.file < b.file) {
+                return -1;
+              }
               return 1;
-            }
-            if (a.file < b.file) {
-              return -1;
-            }
-            return 1;
-          });
+            });
 
-        // eslint-disable-next-line no-param-reassign
-        chunkNamesToModules[
-          `${asset.chunkNames[0]}.${asset.name.endsWith('.mjs') ? 'mjs' : 'js'}`
-        ] = assetModules;
-      });
-    return chunkNamesToModules;
-  }, {} as ChunkNamesToModules);
+          // eslint-disable-next-line no-param-reassign
+          chunkNamesToModules[
+            `${asset.chunkNames[0]}.${asset.name.endsWith('.mjs') ? 'mjs' : 'js'}`
+          ] = assetModules;
+        });
+      return chunkNamesToModules;
+    },
+    {} as ChunkNamesToModules
+  );
 
   if (Object.keys(mapped).length) {
     return mapped;

--- a/src/helpers/mapChunkNamesWithModules.ts
+++ b/src/helpers/mapChunkNamesWithModules.ts
@@ -3,13 +3,8 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import {
-  Asset,
-  FILENAME_JS_MJS_EXTENSIONS,
-  FILENAME_QUERY_REGEXP,
-  Module,
-  Stats,
-} from './constants';
+import { FILENAME_JS_MJS_EXTENSIONS, FILENAME_QUERY_REGEXP } from './constants';
+import { Asset, Module, Stats } from '../types';
 import { ExtractedStats } from './extractStats';
 
 export interface ChunkModule {

--- a/src/helpers/normalizeStats.test.ts
+++ b/src/helpers/normalizeStats.test.ts
@@ -2,8 +2,8 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import { Stats4, Stats5 } from '../types';
-import extractStats, { ExtractedStats4, ExtractedStats5 } from './extractStats';
+import { NormalizedStats4, NormalizedStats5, Stats4, Stats5 } from '../types';
+import normalizeStats from './normalizeStats';
 
 const baseStats: Stats5 = {
   version: '5.9.0',
@@ -86,10 +86,10 @@ const stats4WithAssetsAndChildren: Stats4 = {
   ],
 };
 
-describe('extractStats', () => {
+describe('normalizeStats', () => {
   describe('webpack v5', () => {
     it('returns stats (single compile - no assets, no children)', () => {
-      expect(extractStats(baseStats)).toEqual<ExtractedStats5>({
+      expect(normalizeStats(baseStats)).toEqual<NormalizedStats5>({
         majorVersion: 5,
         stats: [baseStats],
         original: baseStats,
@@ -102,7 +102,7 @@ describe('extractStats', () => {
       } as Stats5;
       delete noVersionStats.version;
 
-      expect(extractStats(noVersionStats)).toEqual<ExtractedStats5>({
+      expect(normalizeStats(noVersionStats)).toEqual<NormalizedStats5>({
         majorVersion: 5,
         stats: [noVersionStats],
         original: noVersionStats,
@@ -110,7 +110,7 @@ describe('extractStats', () => {
     });
 
     it('returns stats (single compile - assets, no children)', () => {
-      expect(extractStats(statsWithAssets)).toEqual<ExtractedStats5>({
+      expect(normalizeStats(statsWithAssets)).toEqual<NormalizedStats5>({
         majorVersion: 5,
         stats: [statsWithAssets],
         original: statsWithAssets,
@@ -118,7 +118,7 @@ describe('extractStats', () => {
     });
 
     it('returns stats (single compile - assets, children', () => {
-      expect(extractStats(statsWithAssetsAndChildren)).toEqual<ExtractedStats5>({
+      expect(normalizeStats(statsWithAssetsAndChildren)).toEqual<NormalizedStats5>({
         majorVersion: 5,
         stats: [statsWithAssetsAndChildren],
         original: statsWithAssetsAndChildren,
@@ -132,7 +132,7 @@ describe('extractStats', () => {
         children,
       };
 
-      expect(extractStats(multiCompileStats)).toEqual<ExtractedStats5>({
+      expect(normalizeStats(multiCompileStats)).toEqual<NormalizedStats5>({
         majorVersion: 5,
         stats: children,
         original: multiCompileStats,
@@ -142,7 +142,7 @@ describe('extractStats', () => {
     it('returns stats (parallel-webpack --profile --json flags)', () => {
       const children = [statsWithAssets, statsWithAssetsAndChildren];
 
-      expect(extractStats(children)).toEqual<ExtractedStats5>({
+      expect(normalizeStats(children)).toEqual<NormalizedStats5>({
         majorVersion: 5,
         stats: children,
         original: children as unknown,
@@ -152,7 +152,7 @@ describe('extractStats', () => {
 
   describe('webpack v4', () => {
     it('returns stats (single compile - no assets, no children)', () => {
-      expect(extractStats(base4Stats)).toEqual<ExtractedStats4>({
+      expect(normalizeStats(base4Stats)).toEqual<NormalizedStats4>({
         majorVersion: 4,
         stats: [base4Stats],
         original: base4Stats,
@@ -165,7 +165,7 @@ describe('extractStats', () => {
       } as Stats4;
       delete noVersionStats.version;
 
-      expect(extractStats(noVersionStats)).toEqual<ExtractedStats4>({
+      expect(normalizeStats(noVersionStats)).toEqual<NormalizedStats4>({
         majorVersion: 4,
         stats: [noVersionStats],
         original: noVersionStats,
@@ -173,7 +173,7 @@ describe('extractStats', () => {
     });
 
     it('returns stats (single compile - assets, no children)', () => {
-      expect(extractStats(stats4WithAssets)).toEqual<ExtractedStats4>({
+      expect(normalizeStats(stats4WithAssets)).toEqual<NormalizedStats4>({
         majorVersion: 4,
         stats: [stats4WithAssets],
         original: stats4WithAssets,
@@ -181,7 +181,7 @@ describe('extractStats', () => {
     });
 
     it('returns stats (single compile - assets, children', () => {
-      expect(extractStats(stats4WithAssetsAndChildren)).toEqual<ExtractedStats4>({
+      expect(normalizeStats(stats4WithAssetsAndChildren)).toEqual<NormalizedStats4>({
         majorVersion: 4,
         stats: [stats4WithAssetsAndChildren],
         original: stats4WithAssetsAndChildren,
@@ -195,7 +195,7 @@ describe('extractStats', () => {
         children,
       };
 
-      expect(extractStats(multiCompileStats)).toEqual<ExtractedStats4>({
+      expect(normalizeStats(multiCompileStats)).toEqual<NormalizedStats4>({
         majorVersion: 4,
         stats: children,
         original: multiCompileStats,
@@ -205,7 +205,7 @@ describe('extractStats', () => {
     it('returns stats (parallel-webpack --profile --json flags)', () => {
       const children = [stats4WithAssets, stats4WithAssetsAndChildren];
 
-      expect(extractStats(children)).toEqual<ExtractedStats4>({
+      expect(normalizeStats(children)).toEqual<NormalizedStats4>({
         majorVersion: 4,
         stats: children,
         original: children as unknown,

--- a/src/helpers/normalizeStats.ts
+++ b/src/helpers/normalizeStats.ts
@@ -3,27 +3,14 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import { Stats, Stats4, Stats5 } from '../types';
-
-export type ExtractedStats = ExtractedStats5 | ExtractedStats4;
-
-interface BaseExtractedStats {
-  majorVersion: 4 | 5;
-  stats: Stats[];
-  original: Stats;
-}
-
-export interface ExtractedStats5 extends BaseExtractedStats {
-  majorVersion: 5;
-  stats: Stats5[];
-  original: Stats;
-}
-
-export interface ExtractedStats4 extends BaseExtractedStats {
-  majorVersion: 4;
-  stats: Stats4[];
-  original: Stats;
-}
+import {
+  NormalizedStats,
+  NormalizedStats4,
+  NormalizedStats5,
+  Stats,
+  Stats4,
+  Stats5,
+} from '../types';
 
 const isVersion4Stats = (stats: Stats) => {
   if (stats?.version?.startsWith('5.')) {
@@ -33,7 +20,7 @@ const isVersion4Stats = (stats: Stats) => {
   return typeof (stats as Stats5).assets?.[0]?.type === 'undefined';
 };
 
-const extractStats = (compilationStats: Stats | Stats[]): ExtractedStats => {
+const normalizeStats = (compilationStats: Stats | Stats[]): NormalizedStats => {
   // parallel-webpack output
   if (Array.isArray(compilationStats)) {
     const singleStats = compilationStats[0];
@@ -42,14 +29,14 @@ const extractStats = (compilationStats: Stats | Stats[]): ExtractedStats => {
         majorVersion: 4,
         stats: compilationStats as Stats4[],
         original: compilationStats as unknown,
-      } as ExtractedStats4;
+      } as NormalizedStats4;
     }
 
     return {
       majorVersion: 5,
       stats: compilationStats as Stats5[],
       original: compilationStats as unknown,
-    } as ExtractedStats5;
+    } as NormalizedStats5;
   }
 
   if (!compilationStats.assets && compilationStats.children && compilationStats.children.length) {
@@ -59,14 +46,14 @@ const extractStats = (compilationStats: Stats | Stats[]): ExtractedStats => {
         majorVersion: 4,
         stats: compilationStats.children as Stats4[],
         original: compilationStats as unknown,
-      } as ExtractedStats4;
+      } as NormalizedStats4;
     }
 
     return {
       majorVersion: 5,
       stats: compilationStats.children as Stats5[],
       original: compilationStats as unknown,
-    } as ExtractedStats5;
+    } as NormalizedStats5;
   }
 
   if (isVersion4Stats(compilationStats)) {
@@ -74,14 +61,14 @@ const extractStats = (compilationStats: Stats | Stats[]): ExtractedStats => {
       majorVersion: 4,
       stats: [compilationStats] as Stats4[],
       original: compilationStats as unknown,
-    } as ExtractedStats4;
+    } as NormalizedStats4;
   }
 
   return {
     majorVersion: 5,
     stats: [compilationStats] as Stats5[],
     original: compilationStats as unknown,
-  } as ExtractedStats5;
+  } as NormalizedStats5;
 };
 
-export default extractStats;
+export default normalizeStats;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license information.
  */
 export { default as danger } from './danger';
-export { default as extractStats } from './helpers/extractStats';
+export { default as normalizeStats } from './helpers/normalizeStats';
 export { default as mapChunkNamesExtensionsToSize } from './helpers/mapChunkNamesExtensionsToSize';
 export { default as mapChunkNamesWithModules } from './helpers/mapChunkNamesWithModules';
 export { default as MergeCompilationStatsWebpackPlugin } from './helpers/MergeCompilationStatsWebpackPlugin';

--- a/src/plugins/BasePlugin.ts
+++ b/src/plugins/BasePlugin.ts
@@ -3,12 +3,11 @@
  * See LICENSE.md in the project root for license information.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
+import { Stats4 } from '../helpers/constants';
 
 export interface BasePluginOptions {
-  baseCompilationStats: webpack4.Stats.ToJsonOutput;
-  headCompilationStats: webpack4.Stats.ToJsonOutput;
+  baseCompilationStats: Stats4;
+  headCompilationStats: Stats4;
   config: unknown;
 }
 

--- a/src/plugins/BasePlugin.ts
+++ b/src/plugins/BasePlugin.ts
@@ -4,11 +4,11 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 
 export interface BasePluginOptions {
-  baseCompilationStats: webpack.Stats.ToJsonOutput;
-  headCompilationStats: webpack.Stats.ToJsonOutput;
+  baseCompilationStats: webpack4.Stats.ToJsonOutput;
+  headCompilationStats: webpack4.Stats.ToJsonOutput;
   config: unknown;
 }
 

--- a/src/plugins/BasePlugin.ts
+++ b/src/plugins/BasePlugin.ts
@@ -3,11 +3,11 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import { Stats4 } from '../helpers/constants';
+import { ExtractedStats } from '../helpers/extractStats';
 
 export interface BasePluginOptions {
-  baseCompilationStats: Stats4;
-  headCompilationStats: Stats4;
+  baseCompilationStats: ExtractedStats;
+  headCompilationStats: ExtractedStats;
   config: unknown;
 }
 

--- a/src/plugins/BasePlugin.ts
+++ b/src/plugins/BasePlugin.ts
@@ -3,11 +3,11 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import { ExtractedStats } from '../helpers/extractStats';
+import { NormalizedStats } from '../types';
 
 export interface BasePluginOptions {
-  baseCompilationStats: ExtractedStats;
-  headCompilationStats: ExtractedStats;
+  baseCompilationStats: NormalizedStats;
+  headCompilationStats: NormalizedStats;
   config: unknown;
 }
 

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -62,7 +62,7 @@ Every plugin should do the following:
 - Create a class extending the [`BasePlugin`](BasePlugin.ts) implementing the necessary methods:
   - `constructor`: extend the `BasePluginOptions` where `config` will be the configuration of your plugin (passed to it by [`index.ts`](index.ts))
     - Be sure to parse both the `baseCompilationStats` and `headCompilationStats` provided to the constructor
-    - Both `base` and `head` stats will have been passed through the [`extractStats`](../helpers/extractStats.ts) to provide either a normalized array of stats, or the original format
+    - Both `base` and `head` stats will have been passed through the [`normalizeStats`](../helpers/normalizeStats.ts) to provide a consistent approach when dealing with the stats
     - It is best to work with the `.stats` property which is the normalized stats, i.e. forcing the stats to always be an array to make it easier to work with both single and multi-compile configurations
   - `summaryOutput`: short output (with no markdown content) to describe the result
     - If this isn't necessary for the plugin, return `null` or `''`

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -62,6 +62,8 @@ Every plugin should do the following:
 - Create a class extending the [`BasePlugin`](BasePlugin.ts) implementing the necessary methods:
   - `constructor`: extend the `BasePluginOptions` where `config` will be the configuration of your plugin (passed to it by [`index.ts`](index.ts))
     - Be sure to parse both the `baseCompilationStats` and `headCompilationStats` provided to the constructor
+    - Both `base` and `head` stats will have been passed through the [`extractStats`](../helpers/extractStats.ts) to provide either a normalized array of stats, or the original format
+    - It is best to work with the `.stats` property which is the normalized stats, i.e. forcing the stats to always be an array to make it easier to work with both single and multi-compile configurations
   - `summaryOutput`: short output (with no markdown content) to describe the result
     - If this isn't necessary for the plugin, return `null` or `''`
   - `dangerOutput`: output to be placed within the collapsed content of the PR comment which includes greater detail as ot the result of the plugin
@@ -77,15 +79,6 @@ Every plugin should do the following:
 - Add the default configuration to [../config/allPlugins.ts](../config/allPlugins.ts)
   - If the plugin does not require configuration, set `config` to `true`
   - If the plugin should not be run without application knowledge (such as the [Restrict Plugin](./restrict)), set `config` to `false` (which will negate its usage)
-- When parsing webpack compilation stats files, it is best to do so with the following template (which ensure both webpack single AND multi-compile parsing support):
-  ``` javascript
-  import { extractStats } from 'webpack-bundle-delta';
-
-  const yourPluginLogic = (compilationStats: webpack.Stats.ToJsonOutput) => {
-    const statsToParse: webpack.Stats.ToJsonOutput[] = extractStats(compilationStats);
-    // use `statsToParse` to determine logic - map, reduce, etc.
-  };
-  ```
 
 If you wish to create your own plugin, you can either publish it as a node package or have the code simply live somewhere within your repo. Then refer to it in the `name` property on the Usage (documented above).
 

--- a/src/plugins/duplication-detection/index.test.ts
+++ b/src/plugins/duplication-detection/index.test.ts
@@ -2,23 +2,23 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import DuplicationDetectionPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { defaultDuplicationDetectionConfig } from './config';
 
-const baseStats = (baseCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
-const headStats = (headCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
+const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
 
-const slimmedBaseStats: webpack.Stats.ToJsonOutput = {
+const slimmedBaseStats: webpack4.Stats.ToJsonOutput = {
   ...baseStats.children[0],
   assets: baseStats.children[0].assets.filter((asset) =>
     asset.name.startsWith('sgpTrainTimesPage')
   ),
 };
 
-const slimmedHeadBaseStats: webpack.Stats.ToJsonOutput = {
+const slimmedHeadBaseStats: webpack4.Stats.ToJsonOutput = {
   ...headStats.children[0],
   assets: headStats.children[0].assets.filter(
     (asset) => asset.name.startsWith('sgpTrainTimesPage') || asset.name.startsWith('sgpStationPage')

--- a/src/plugins/duplication-detection/index.test.ts
+++ b/src/plugins/duplication-detection/index.test.ts
@@ -7,23 +7,24 @@ import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { defaultDuplicationDetectionConfig } from './config';
 import { Stats4 } from '../../helpers/constants';
+import extractStats from '../../helpers/extractStats';
 
 const baseStats = (baseCompilationStats as unknown) as Stats4;
 const headStats = (headCompilationStats as unknown) as Stats4;
 
-const slimmedBaseStats: Stats4 = {
+const slimmedBaseStats = extractStats({
   ...baseStats.children[0],
   assets: baseStats.children[0].assets.filter((asset) =>
     asset.name.startsWith('sgpTrainTimesPage')
   ),
-};
+} as Stats4);
 
-const slimmedHeadBaseStats: Stats4 = {
+const slimmedHeadBaseStats = extractStats({
   ...headStats.children[0],
   assets: headStats.children[0].assets.filter(
     (asset) => asset.name.startsWith('sgpTrainTimesPage') || asset.name.startsWith('sgpStationPage')
   ),
-};
+} as Stats4);
 
 describe('DuplicationDetectionPlugin', () => {
   let duplicationDetection: DuplicationDetectionPlugin;

--- a/src/plugins/duplication-detection/index.test.ts
+++ b/src/plugins/duplication-detection/index.test.ts
@@ -7,19 +7,19 @@ import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { defaultDuplicationDetectionConfig } from './config';
 import { Stats4 } from '../../types';
-import extractStats from '../../helpers/extractStats';
+import normalizeStats from '../../helpers/normalizeStats';
 
 const baseStats = (baseCompilationStats as unknown) as Stats4;
 const headStats = (headCompilationStats as unknown) as Stats4;
 
-const slimmedBaseStats = extractStats({
+const slimmedBaseStats = normalizeStats({
   ...baseStats.children[0],
   assets: baseStats.children[0].assets.filter((asset) =>
     asset.name.startsWith('sgpTrainTimesPage')
   ),
 } as Stats4);
 
-const slimmedHeadBaseStats = extractStats({
+const slimmedHeadBaseStats = normalizeStats({
   ...headStats.children[0],
   assets: headStats.children[0].assets.filter(
     (asset) => asset.name.startsWith('sgpTrainTimesPage') || asset.name.startsWith('sgpStationPage')

--- a/src/plugins/duplication-detection/index.test.ts
+++ b/src/plugins/duplication-detection/index.test.ts
@@ -6,7 +6,7 @@ import DuplicationDetectionPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { defaultDuplicationDetectionConfig } from './config';
-import { Stats4 } from '../../helpers/constants';
+import { Stats4 } from '../../types';
 import extractStats from '../../helpers/extractStats';
 
 const baseStats = (baseCompilationStats as unknown) as Stats4;

--- a/src/plugins/duplication-detection/index.test.ts
+++ b/src/plugins/duplication-detection/index.test.ts
@@ -2,23 +2,23 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack4 from 'webpack4';
 import DuplicationDetectionPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { defaultDuplicationDetectionConfig } from './config';
+import { Stats4 } from '../../helpers/constants';
 
-const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
-const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const baseStats = (baseCompilationStats as unknown) as Stats4;
+const headStats = (headCompilationStats as unknown) as Stats4;
 
-const slimmedBaseStats: webpack4.Stats.ToJsonOutput = {
+const slimmedBaseStats: Stats4 = {
   ...baseStats.children[0],
   assets: baseStats.children[0].assets.filter((asset) =>
     asset.name.startsWith('sgpTrainTimesPage')
   ),
 };
 
-const slimmedHeadBaseStats: webpack4.Stats.ToJsonOutput = {
+const slimmedHeadBaseStats: Stats4 = {
   ...headStats.children[0],
   assets: headStats.children[0].assets.filter(
     (asset) => asset.name.startsWith('sgpTrainTimesPage') || asset.name.startsWith('sgpStationPage')

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -7,12 +7,12 @@ import fs from 'fs';
 import path from 'path';
 import BasePlugin from './BasePlugin';
 import { UserDefinedConfig } from '../config/PluginConfig';
-import { ExtractedStats } from '../helpers/extractStats';
+import { NormalizedStats } from '../types';
 
 const plugins = async (
   userDefinedConfig: UserDefinedConfig,
-  baseCompilationStats: ExtractedStats,
-  headCompilationStats: ExtractedStats
+  baseCompilationStats: NormalizedStats,
+  headCompilationStats: NormalizedStats
 ): Promise<BasePlugin[]> => {
   return (userDefinedConfig.plugins || [])
     .map(({ name, config }) => {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import fs from 'fs';
 import path from 'path';
 import BasePlugin from './BasePlugin';
@@ -12,8 +12,8 @@ import { UserDefinedConfig } from '../config/PluginConfig';
 
 const plugins = async (
   userDefinedConfig: UserDefinedConfig,
-  baseCompilationStats: webpack.Stats.ToJsonOutput,
-  headCompilationStats: webpack.Stats.ToJsonOutput
+  baseCompilationStats: webpack4.Stats.ToJsonOutput,
+  headCompilationStats: webpack4.Stats.ToJsonOutput
 ): Promise<BasePlugin[]> => {
   return (userDefinedConfig.plugins || [])
     .map(({ name, config }) => {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -3,17 +3,16 @@
  * See LICENSE.md in the project root for license information.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
 import fs from 'fs';
 import path from 'path';
 import BasePlugin from './BasePlugin';
 import { UserDefinedConfig } from '../config/PluginConfig';
+import { Stats4 } from '../helpers/constants';
 
 const plugins = async (
   userDefinedConfig: UserDefinedConfig,
-  baseCompilationStats: webpack4.Stats.ToJsonOutput,
-  headCompilationStats: webpack4.Stats.ToJsonOutput
+  baseCompilationStats: Stats4,
+  headCompilationStats: Stats4
 ): Promise<BasePlugin[]> => {
   return (userDefinedConfig.plugins || [])
     .map(({ name, config }) => {

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -7,12 +7,12 @@ import fs from 'fs';
 import path from 'path';
 import BasePlugin from './BasePlugin';
 import { UserDefinedConfig } from '../config/PluginConfig';
-import { Stats4 } from '../helpers/constants';
+import { ExtractedStats } from '../helpers/extractStats';
 
 const plugins = async (
   userDefinedConfig: UserDefinedConfig,
-  baseCompilationStats: Stats4,
-  headCompilationStats: Stats4
+  baseCompilationStats: ExtractedStats,
+  headCompilationStats: ExtractedStats
 ): Promise<BasePlugin[]> => {
   return (userDefinedConfig.plugins || [])
     .map(({ name, config }) => {

--- a/src/plugins/resolve-alias-remap/AliasRemap.ts
+++ b/src/plugins/resolve-alias-remap/AliasRemap.ts
@@ -4,10 +4,10 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 
 export interface aliasEntryFn {
-  (module: webpack.Stats.FnModules, stats: webpack.Stats.ToJsonOutput): string;
+  (module: webpack4.Stats.FnModules, stats: webpack4.Stats.ToJsonOutput): string;
 }
 
 export interface AliasRemap {

--- a/src/plugins/resolve-alias-remap/AliasRemap.ts
+++ b/src/plugins/resolve-alias-remap/AliasRemap.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import { Module, Stats } from '../../helpers/constants';
+import { Module, Stats } from '../../types';
 
 export interface aliasEntryFn {
   (module: Module, stats: Stats): string;

--- a/src/plugins/resolve-alias-remap/AliasRemap.ts
+++ b/src/plugins/resolve-alias-remap/AliasRemap.ts
@@ -3,11 +3,10 @@
  * See LICENSE.md in the project root for license information.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
+import { Module, Stats4 } from '../../helpers/constants';
 
 export interface aliasEntryFn {
-  (module: webpack4.Stats.FnModules, stats: webpack4.Stats.ToJsonOutput): string;
+  (module: Module, stats: Stats4): string;
 }
 
 export interface AliasRemap {

--- a/src/plugins/resolve-alias-remap/AliasRemap.ts
+++ b/src/plugins/resolve-alias-remap/AliasRemap.ts
@@ -3,10 +3,10 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import { Module, Stats4 } from '../../helpers/constants';
+import { Module, Stats } from '../../helpers/constants';
 
 export interface aliasEntryFn {
-  (module: Module, stats: Stats4): string;
+  (module: Module, stats: Stats): string;
 }
 
 export interface AliasRemap {

--- a/src/plugins/resolve-alias-remap/index.test.ts
+++ b/src/plugins/resolve-alias-remap/index.test.ts
@@ -7,9 +7,10 @@ import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { defaultResolveAliasRemapConfig } from './config';
 import { Stats4 } from '../../helpers/constants';
+import extractStats from '../../helpers/extractStats';
 
-const baseStats = (baseCompilationStats as unknown) as Stats4;
-const headStats = (headCompilationStats as unknown) as Stats4;
+const extractedBaseStats = extractStats((baseCompilationStats as unknown) as Stats4);
+const extractedHeadStats = extractStats((headCompilationStats as unknown) as Stats4);
 
 describe('ResolveAliasRemapPlugin', () => {
   let resolveAliasRemap: ResolveAliasRemapPlugin;
@@ -17,8 +18,8 @@ describe('ResolveAliasRemapPlugin', () => {
   describe('only new suggestions', () => {
     beforeEach(() => {
       resolveAliasRemap = new ResolveAliasRemapPlugin({
-        baseCompilationStats: baseStats,
-        headCompilationStats: headStats,
+        baseCompilationStats: extractedBaseStats,
+        headCompilationStats: extractedHeadStats,
         config: {
           ...defaultResolveAliasRemapConfig,
           showExisting: false,
@@ -42,8 +43,8 @@ describe('ResolveAliasRemapPlugin', () => {
   describe('existing suggestions', () => {
     beforeEach(() => {
       resolveAliasRemap = new ResolveAliasRemapPlugin({
-        baseCompilationStats: baseStats,
-        headCompilationStats: headStats,
+        baseCompilationStats: extractedBaseStats,
+        headCompilationStats: extractedHeadStats,
         config: {
           ...defaultResolveAliasRemapConfig,
           showExisting: true,

--- a/src/plugins/resolve-alias-remap/index.test.ts
+++ b/src/plugins/resolve-alias-remap/index.test.ts
@@ -6,7 +6,7 @@ import ResolveAliasRemapPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { defaultResolveAliasRemapConfig } from './config';
-import { Stats4 } from '../../helpers/constants';
+import { Stats4 } from '../../types';
 import extractStats from '../../helpers/extractStats';
 
 const extractedBaseStats = extractStats((baseCompilationStats as unknown) as Stats4);

--- a/src/plugins/resolve-alias-remap/index.test.ts
+++ b/src/plugins/resolve-alias-remap/index.test.ts
@@ -2,14 +2,14 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack4 from 'webpack4';
 import ResolveAliasRemapPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { defaultResolveAliasRemapConfig } from './config';
+import { Stats4 } from '../../helpers/constants';
 
-const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
-const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const baseStats = (baseCompilationStats as unknown) as Stats4;
+const headStats = (headCompilationStats as unknown) as Stats4;
 
 describe('ResolveAliasRemapPlugin', () => {
   let resolveAliasRemap: ResolveAliasRemapPlugin;

--- a/src/plugins/resolve-alias-remap/index.test.ts
+++ b/src/plugins/resolve-alias-remap/index.test.ts
@@ -2,14 +2,14 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import ResolveAliasRemapPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { defaultResolveAliasRemapConfig } from './config';
 
-const baseStats = (baseCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
-const headStats = (headCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
+const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
 
 describe('ResolveAliasRemapPlugin', () => {
   let resolveAliasRemap: ResolveAliasRemapPlugin;

--- a/src/plugins/resolve-alias-remap/index.test.ts
+++ b/src/plugins/resolve-alias-remap/index.test.ts
@@ -7,10 +7,10 @@ import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { defaultResolveAliasRemapConfig } from './config';
 import { Stats4 } from '../../types';
-import extractStats from '../../helpers/extractStats';
+import normalizeStats from '../../helpers/normalizeStats';
 
-const extractedBaseStats = extractStats((baseCompilationStats as unknown) as Stats4);
-const extractedHeadStats = extractStats((headCompilationStats as unknown) as Stats4);
+const normalizedBaseStats = normalizeStats((baseCompilationStats as unknown) as Stats4);
+const normalizedHeadStats = normalizeStats((headCompilationStats as unknown) as Stats4);
 
 describe('ResolveAliasRemapPlugin', () => {
   let resolveAliasRemap: ResolveAliasRemapPlugin;
@@ -18,8 +18,8 @@ describe('ResolveAliasRemapPlugin', () => {
   describe('only new suggestions', () => {
     beforeEach(() => {
       resolveAliasRemap = new ResolveAliasRemapPlugin({
-        baseCompilationStats: extractedBaseStats,
-        headCompilationStats: extractedHeadStats,
+        baseCompilationStats: normalizedBaseStats,
+        headCompilationStats: normalizedHeadStats,
         config: {
           ...defaultResolveAliasRemapConfig,
           showExisting: false,
@@ -43,8 +43,8 @@ describe('ResolveAliasRemapPlugin', () => {
   describe('existing suggestions', () => {
     beforeEach(() => {
       resolveAliasRemap = new ResolveAliasRemapPlugin({
-        baseCompilationStats: extractedBaseStats,
-        headCompilationStats: extractedHeadStats,
+        baseCompilationStats: normalizedBaseStats,
+        headCompilationStats: normalizedHeadStats,
         config: {
           ...defaultResolveAliasRemapConfig,
           showExisting: true,

--- a/src/plugins/resolve-alias-remap/resolveAliasRemap.test.ts
+++ b/src/plugins/resolve-alias-remap/resolveAliasRemap.test.ts
@@ -2,10 +2,10 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import resolveAliasRemap, { ResolveAliasRemapSuggestion } from './resolveAliasRemap';
 
-const stats: webpack.Stats.ToJsonOutput = {
+const stats: webpack4.Stats.ToJsonOutput = {
   _showErrors: false,
   _showWarnings: false,
   errors: [],
@@ -13,10 +13,10 @@ const stats: webpack.Stats.ToJsonOutput = {
   modules: [
     ({
       name: './node_modules/lodash/_getNative.js',
-    } as unknown) as webpack.Stats.FnModules,
+    } as unknown) as webpack4.Stats.FnModules,
     ({
       name: './node_modules/lodash.omitby/index.js',
-    } as unknown) as webpack.Stats.FnModules,
+    } as unknown) as webpack4.Stats.FnModules,
   ],
 };
 

--- a/src/plugins/resolve-alias-remap/resolveAliasRemap.test.ts
+++ b/src/plugins/resolve-alias-remap/resolveAliasRemap.test.ts
@@ -3,10 +3,10 @@
  * See LICENSE.md in the project root for license information.
  */
 
-import extractStats from '../../helpers/extractStats';
+import normalizeStats from '../../helpers/normalizeStats';
 import resolveAliasRemap, { ResolveAliasRemapSuggestion } from './resolveAliasRemap';
 
-const extractedStats = extractStats({
+const normalizedStats = normalizeStats({
   modules: [
     {
       name: './node_modules/lodash/_getNative.js',
@@ -20,7 +20,7 @@ const extractedStats = extractStats({
 describe('resolveAliasRemap', () => {
   it('returns the expected alias remap suggestion for lodash.omitby (string alias entry)', () => {
     expect(
-      resolveAliasRemap(extractedStats, [
+      resolveAliasRemap(normalizedStats, [
         { searchFor: 'lodash\\.([^/]+)', aliasEntry: 'lodash.$1: lodash/$1' },
       ])
     ).toEqual<ResolveAliasRemapSuggestion[]>([
@@ -33,7 +33,7 @@ describe('resolveAliasRemap', () => {
 
   it('returns the expected alias remap suggestion for lodash.omitby (function alias entry)', () => {
     expect(
-      resolveAliasRemap(extractedStats, [
+      resolveAliasRemap(normalizedStats, [
         { searchFor: 'lodash\\.([^/]+)', aliasEntry: () => 'some-remap' },
       ])
     ).toEqual<ResolveAliasRemapSuggestion[]>([
@@ -46,13 +46,13 @@ describe('resolveAliasRemap', () => {
 
   it('does not return suggestion when aliasEntry string is empty', () => {
     expect(
-      resolveAliasRemap(extractedStats, [{ searchFor: 'lodash\\.([^/]+)', aliasEntry: '' }])
+      resolveAliasRemap(normalizedStats, [{ searchFor: 'lodash\\.([^/]+)', aliasEntry: '' }])
     ).toEqual([]);
   });
 
   it('does not return suggestion when aliasEntry function returns empty', () => {
     expect(
-      resolveAliasRemap(extractedStats, [{ searchFor: 'lodash\\.([^/]+)', aliasEntry: () => '' }])
+      resolveAliasRemap(normalizedStats, [{ searchFor: 'lodash\\.([^/]+)', aliasEntry: () => '' }])
     ).toEqual([]);
   });
 });

--- a/src/plugins/resolve-alias-remap/resolveAliasRemap.test.ts
+++ b/src/plugins/resolve-alias-remap/resolveAliasRemap.test.ts
@@ -3,9 +3,10 @@
  * See LICENSE.md in the project root for license information.
  */
 import webpack4 from 'webpack4';
+import { Stats4 } from '../../helpers/constants';
 import resolveAliasRemap, { ResolveAliasRemapSuggestion } from './resolveAliasRemap';
 
-const stats: webpack4.Stats.ToJsonOutput = {
+const stats: Stats4 = {
   _showErrors: false,
   _showWarnings: false,
   errors: [],

--- a/src/plugins/resolve-alias-remap/resolveAliasRemap.test.ts
+++ b/src/plugins/resolve-alias-remap/resolveAliasRemap.test.ts
@@ -2,29 +2,25 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack4 from 'webpack4';
-import { Stats4 } from '../../helpers/constants';
+
+import extractStats from '../../helpers/extractStats';
 import resolveAliasRemap, { ResolveAliasRemapSuggestion } from './resolveAliasRemap';
 
-const stats: Stats4 = {
-  _showErrors: false,
-  _showWarnings: false,
-  errors: [],
-  warnings: [],
+const extractedStats = extractStats({
   modules: [
-    ({
+    {
       name: './node_modules/lodash/_getNative.js',
-    } as unknown) as webpack4.Stats.FnModules,
-    ({
+    },
+    {
       name: './node_modules/lodash.omitby/index.js',
-    } as unknown) as webpack4.Stats.FnModules,
+    },
   ],
-};
+});
 
 describe('resolveAliasRemap', () => {
   it('returns the expected alias remap suggestion for lodash.omitby (string alias entry)', () => {
     expect(
-      resolveAliasRemap(stats, [
+      resolveAliasRemap(extractedStats, [
         { searchFor: 'lodash\\.([^/]+)', aliasEntry: 'lodash.$1: lodash/$1' },
       ])
     ).toEqual<ResolveAliasRemapSuggestion[]>([
@@ -37,7 +33,9 @@ describe('resolveAliasRemap', () => {
 
   it('returns the expected alias remap suggestion for lodash.omitby (function alias entry)', () => {
     expect(
-      resolveAliasRemap(stats, [{ searchFor: 'lodash\\.([^/]+)', aliasEntry: () => 'some-remap' }])
+      resolveAliasRemap(extractedStats, [
+        { searchFor: 'lodash\\.([^/]+)', aliasEntry: () => 'some-remap' },
+      ])
     ).toEqual<ResolveAliasRemapSuggestion[]>([
       {
         name: './node_modules/lodash.omitby/index.js',
@@ -47,14 +45,14 @@ describe('resolveAliasRemap', () => {
   });
 
   it('does not return suggestion when aliasEntry string is empty', () => {
-    expect(resolveAliasRemap(stats, [{ searchFor: 'lodash\\.([^/]+)', aliasEntry: '' }])).toEqual(
-      []
-    );
+    expect(
+      resolveAliasRemap(extractedStats, [{ searchFor: 'lodash\\.([^/]+)', aliasEntry: '' }])
+    ).toEqual([]);
   });
 
   it('does not return suggestion when aliasEntry function returns empty', () => {
     expect(
-      resolveAliasRemap(stats, [{ searchFor: 'lodash\\.([^/]+)', aliasEntry: () => '' }])
+      resolveAliasRemap(extractedStats, [{ searchFor: 'lodash\\.([^/]+)', aliasEntry: () => '' }])
     ).toEqual([]);
   });
 });

--- a/src/plugins/resolve-alias-remap/resolveAliasRemap.ts
+++ b/src/plugins/resolve-alias-remap/resolveAliasRemap.ts
@@ -4,8 +4,7 @@
  */
 
 import { AliasRemap } from './AliasRemap';
-import { ExtractedStats } from '../../helpers/extractStats';
-import { Module, Stats } from '../../types';
+import { NormalizedStats, Module, Stats } from '../../types';
 
 export interface ResolveAliasRemapSuggestion {
   name: string;
@@ -13,10 +12,10 @@ export interface ResolveAliasRemapSuggestion {
 }
 
 const resolveAliasRemap = (
-  extractedStats: ExtractedStats,
+  normalizedStats: NormalizedStats,
   aliasRemap: AliasRemap[]
 ): ResolveAliasRemapSuggestion[] => {
-  return (extractedStats.stats as Stats[]).reduce(
+  return (normalizedStats.stats as Stats[]).reduce(
     (result: ResolveAliasRemapSuggestion[], stats) => {
       const remapped = (stats.modules as Module[])
         .map((module) => {

--- a/src/plugins/resolve-alias-remap/resolveAliasRemap.ts
+++ b/src/plugins/resolve-alias-remap/resolveAliasRemap.ts
@@ -4,8 +4,8 @@
  */
 
 import { AliasRemap } from './AliasRemap';
-import extractStats, { ExtractedStats4 } from '../../helpers/extractStats';
-import { Stats4 } from '../../helpers/constants';
+import { ExtractedStats } from '../../helpers/extractStats';
+import { Module, Stats } from '../../helpers/constants';
 
 export interface ResolveAliasRemapSuggestion {
   name: string;
@@ -13,46 +13,49 @@ export interface ResolveAliasRemapSuggestion {
 }
 
 const resolveAliasRemap = (
-  compilationStats: Stats4,
+  extractedStats: ExtractedStats,
   aliasRemap: AliasRemap[]
 ): ResolveAliasRemapSuggestion[] => {
-  return (extractStats(compilationStats) as ExtractedStats4).stats.reduce((result, stats) => {
-    const remapped = stats.modules
-      .map((module) => {
-        const remap = aliasRemap.find(({ searchFor }) => new RegExp(searchFor).test(module.name));
-        if (remap) {
-          const { searchFor, aliasEntry } = remap;
-          let suggestion = '';
+  return (extractedStats.stats as Stats[]).reduce(
+    (result: ResolveAliasRemapSuggestion[], stats) => {
+      const remapped = (stats.modules as Module[])
+        .map((module) => {
+          const remap = aliasRemap.find(({ searchFor }) => new RegExp(searchFor).test(module.name));
+          if (remap) {
+            const { searchFor, aliasEntry } = remap;
+            let suggestion = '';
 
-          if (typeof aliasEntry === 'function') {
-            suggestion = aliasEntry(module, stats);
-          } else {
-            module.name.match(new RegExp(searchFor)).forEach((match, index) => {
-              suggestion = aliasEntry.replace(new RegExp(`\\$${index}`, 'g'), match);
-            });
+            if (typeof aliasEntry === 'function') {
+              suggestion = aliasEntry(module, stats);
+            } else {
+              module.name.match(new RegExp(searchFor)).forEach((match, index) => {
+                suggestion = aliasEntry.replace(new RegExp(`\\$${index}`, 'g'), match);
+              });
+            }
+
+            if (suggestion) {
+              return {
+                name: module.name,
+                suggestion,
+              } as ResolveAliasRemapSuggestion;
+            }
           }
+          return null;
+        })
+        .filter(
+          (remap) =>
+            !!remap && // remove nulls
+            !result.some(
+              // remove ones already in the results array, possibly from other compilations
+              (prevSuggestion) =>
+                prevSuggestion.name === remap.name && prevSuggestion.suggestion === remap.suggestion
+            )
+        );
 
-          if (suggestion) {
-            return {
-              name: module.name,
-              suggestion,
-            } as ResolveAliasRemapSuggestion;
-          }
-        }
-        return null;
-      })
-      .filter(
-        (remap) =>
-          !!remap && // remove nulls
-          !result.some(
-            // remove ones already in the results array, possibly from other compilations
-            (prevSuggestion) =>
-              prevSuggestion.name === remap.name && prevSuggestion.suggestion === remap.suggestion
-          )
-      );
-
-    return result.concat(remapped);
-  }, [] as ResolveAliasRemapSuggestion[]);
+      return result.concat(remapped);
+    },
+    [] as ResolveAliasRemapSuggestion[]
+  );
 };
 
 export default resolveAliasRemap;

--- a/src/plugins/resolve-alias-remap/resolveAliasRemap.ts
+++ b/src/plugins/resolve-alias-remap/resolveAliasRemap.ts
@@ -5,7 +5,7 @@
 
 import { AliasRemap } from './AliasRemap';
 import { ExtractedStats } from '../../helpers/extractStats';
-import { Module, Stats } from '../../helpers/constants';
+import { Module, Stats } from '../../types';
 
 export interface ResolveAliasRemapSuggestion {
   name: string;

--- a/src/plugins/resolve-alias-remap/resolveAliasRemap.ts
+++ b/src/plugins/resolve-alias-remap/resolveAliasRemap.ts
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import { AliasRemap } from './AliasRemap';
 import extractStats from '../../helpers/extractStats';
 
@@ -14,7 +14,7 @@ export interface ResolveAliasRemapSuggestion {
 }
 
 const resolveAliasRemap = (
-  compilationStats: webpack.Stats.ToJsonOutput,
+  compilationStats: webpack4.Stats.ToJsonOutput,
   aliasRemap: AliasRemap[]
 ): ResolveAliasRemapSuggestion[] => {
   return extractStats(compilationStats).reduce((result, stats) => {

--- a/src/plugins/resolve-alias-remap/resolveAliasRemap.ts
+++ b/src/plugins/resolve-alias-remap/resolveAliasRemap.ts
@@ -3,10 +3,9 @@
  * See LICENSE.md in the project root for license information.
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-import webpack4 from 'webpack4';
 import { AliasRemap } from './AliasRemap';
-import extractStats from '../../helpers/extractStats';
+import extractStats, { ExtractedStats4 } from '../../helpers/extractStats';
+import { Stats4 } from '../../helpers/constants';
 
 export interface ResolveAliasRemapSuggestion {
   name: string;
@@ -14,10 +13,10 @@ export interface ResolveAliasRemapSuggestion {
 }
 
 const resolveAliasRemap = (
-  compilationStats: webpack4.Stats.ToJsonOutput,
+  compilationStats: Stats4,
   aliasRemap: AliasRemap[]
 ): ResolveAliasRemapSuggestion[] => {
-  return extractStats(compilationStats).reduce((result, stats) => {
+  return (extractStats(compilationStats) as ExtractedStats4).stats.reduce((result, stats) => {
     const remapped = stats.modules
       .map((module) => {
         const remap = aliasRemap.find(({ searchFor }) => new RegExp(searchFor).test(module.name));

--- a/src/plugins/resolve-alias-remap/suggestions/lodash.test.ts
+++ b/src/plugins/resolve-alias-remap/suggestions/lodash.test.ts
@@ -4,7 +4,7 @@
  */
 import lodashSuggestion from './lodash';
 import { aliasEntryFn } from '../AliasRemap';
-import { Module, Stats } from '../../../helpers/constants';
+import { Module, Stats } from '../../../types';
 
 const aliasEntryFn = lodashSuggestion.aliasEntry as aliasEntryFn;
 const defaultWebpackStats = {} as Stats;

--- a/src/plugins/resolve-alias-remap/suggestions/lodash.test.ts
+++ b/src/plugins/resolve-alias-remap/suggestions/lodash.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import lodashSuggestion from './lodash';
 import { aliasEntryFn } from '../AliasRemap';
 
@@ -12,16 +12,16 @@ const defaultWebpackStats = {
   _showWarnings: false,
   errors: [],
   warnings: [],
-} as webpack.Stats.ToJsonOutput;
+} as webpack4.Stats.ToJsonOutput;
 
 const lodashModule = {
   name: './node_modules/lodash/index.js',
-} as webpack.Stats.FnModules;
+} as webpack4.Stats.FnModules;
 
 describe('ResolveAliasRemap Lodash Suggestion - aliasEntry', () => {
   const lodashOmitBy = {
     name: './node_modules/lodash.omitby/index.js',
-  } as webpack.Stats.FnModules;
+  } as webpack4.Stats.FnModules;
 
   it('returns "" when lodash is not part of the bundle', () => {
     expect(aliasEntryFn(lodashOmitBy, defaultWebpackStats)).toBe('');

--- a/src/plugins/resolve-alias-remap/suggestions/lodash.test.ts
+++ b/src/plugins/resolve-alias-remap/suggestions/lodash.test.ts
@@ -2,35 +2,29 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack4 from 'webpack4';
 import lodashSuggestion from './lodash';
 import { aliasEntryFn } from '../AliasRemap';
-import { Stats4 } from '../../../helpers/constants';
+import { Module, Stats } from '../../../helpers/constants';
 
 const aliasEntryFn = lodashSuggestion.aliasEntry as aliasEntryFn;
-const defaultWebpackStats = {
-  _showErrors: false,
-  _showWarnings: false,
-  errors: [],
-  warnings: [],
-} as Stats4;
+const defaultWebpackStats = {} as Stats;
 
-const lodashModule = {
+const lodashModule: Module = {
   name: './node_modules/lodash/index.js',
-} as webpack4.Stats.FnModules;
+};
 
 describe('ResolveAliasRemap Lodash Suggestion - aliasEntry', () => {
-  const lodashOmitBy = {
+  const lodashOmitBy: Module = {
     name: './node_modules/lodash.omitby/index.js',
-  } as webpack4.Stats.FnModules;
+  };
 
   it('returns "" when lodash is not part of the bundle', () => {
     expect(aliasEntryFn(lodashOmitBy, defaultWebpackStats)).toBe('');
   });
 
   it('returns expected for lodash omit by', () => {
-    expect(aliasEntryFn(lodashOmitBy, { ...defaultWebpackStats, modules: [lodashModule] })).toBe(
-      '"lodash.omitby": "lodash/omitBy"'
-    );
+    expect(
+      aliasEntryFn(lodashOmitBy, { ...defaultWebpackStats, modules: [lodashModule] } as Stats)
+    ).toBe('"lodash.omitby": "lodash/omitBy"');
   });
 });

--- a/src/plugins/resolve-alias-remap/suggestions/lodash.test.ts
+++ b/src/plugins/resolve-alias-remap/suggestions/lodash.test.ts
@@ -5,6 +5,7 @@
 import webpack4 from 'webpack4';
 import lodashSuggestion from './lodash';
 import { aliasEntryFn } from '../AliasRemap';
+import { Stats4 } from '../../../helpers/constants';
 
 const aliasEntryFn = lodashSuggestion.aliasEntry as aliasEntryFn;
 const defaultWebpackStats = {
@@ -12,7 +13,7 @@ const defaultWebpackStats = {
   _showWarnings: false,
   errors: [],
   warnings: [],
-} as webpack4.Stats.ToJsonOutput;
+} as Stats4;
 
 const lodashModule = {
   name: './node_modules/lodash/index.js',

--- a/src/plugins/resolve-alias-remap/suggestions/lodash.ts
+++ b/src/plugins/resolve-alias-remap/suggestions/lodash.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license information.
  */
 import * as lodash from 'lodash';
+import { Module } from '../../../helpers/constants';
 import { aliasEntryFn, AliasRemap } from '../AliasRemap';
 
 // this can have the danger of pulling in methods that it should
@@ -20,7 +21,9 @@ const searchFor = 'lodash\\.([^/]+)';
 const lodashSuggestion: AliasRemap = {
   searchFor,
   aliasEntry: ((module, stats) => {
-    const hasFullLodash = stats.modules?.some(({ name }) => name.includes('/lodash/'));
+    const hasFullLodash = (stats.modules as Module[])?.some(({ name }) =>
+      name.includes('/lodash/')
+    );
     if (!hasFullLodash) {
       // no point suggesting to use full lodash if it doesn't make use of it
       return '';

--- a/src/plugins/resolve-alias-remap/suggestions/lodash.ts
+++ b/src/plugins/resolve-alias-remap/suggestions/lodash.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license information.
  */
 import * as lodash from 'lodash';
-import { Module } from '../../../helpers/constants';
+import { Module } from '../../../types';
 import { aliasEntryFn, AliasRemap } from '../AliasRemap';
 
 // this can have the danger of pulling in methods that it should

--- a/src/plugins/restrict/index.test.ts
+++ b/src/plugins/restrict/index.test.ts
@@ -8,9 +8,10 @@ import headCompilationStats from '../../../test/fixtures/head-compilation-stats.
 import { RestrictConfig } from './config';
 import { defaultBasePluginConfig } from '../../config/PluginConfig';
 import { Stats4 } from '../../helpers/constants';
+import extractStats from '../../helpers/extractStats';
 
-const baseStats = (baseCompilationStats as unknown) as Stats4;
-const headStats = (headCompilationStats as unknown) as Stats4;
+const extractedBaseStats = extractStats((baseCompilationStats as unknown) as Stats4);
+const extractedHeadStats = extractStats((headCompilationStats as unknown) as Stats4);
 const restrictConfig: RestrictConfig = {
   showExisting: false,
   chunkFilename: defaultBasePluginConfig.chunkFilename,
@@ -30,8 +31,8 @@ describe('RestrictPlugin', () => {
   describe('only new restrictions', () => {
     beforeEach(() => {
       restrictPlugin = new RestrictPlugin({
-        baseCompilationStats: baseStats,
-        headCompilationStats: headStats,
+        baseCompilationStats: extractedBaseStats,
+        headCompilationStats: extractedHeadStats,
         config: {
           ...restrictConfig,
           showExisting: false,
@@ -65,8 +66,8 @@ describe('RestrictPlugin', () => {
   describe('existing restrictions', () => {
     beforeEach(() => {
       restrictPlugin = new RestrictPlugin({
-        baseCompilationStats: baseStats,
-        headCompilationStats: headStats,
+        baseCompilationStats: extractedBaseStats,
+        headCompilationStats: extractedHeadStats,
         config: {
           ...restrictConfig,
           showExisting: true,

--- a/src/plugins/restrict/index.test.ts
+++ b/src/plugins/restrict/index.test.ts
@@ -2,15 +2,15 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack4 from 'webpack4';
 import RestrictPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { RestrictConfig } from './config';
 import { defaultBasePluginConfig } from '../../config/PluginConfig';
+import { Stats4 } from '../../helpers/constants';
 
-const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
-const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const baseStats = (baseCompilationStats as unknown) as Stats4;
+const headStats = (headCompilationStats as unknown) as Stats4;
 const restrictConfig: RestrictConfig = {
   showExisting: false,
   chunkFilename: defaultBasePluginConfig.chunkFilename,

--- a/src/plugins/restrict/index.test.ts
+++ b/src/plugins/restrict/index.test.ts
@@ -7,7 +7,7 @@ import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { RestrictConfig } from './config';
 import { defaultBasePluginConfig } from '../../config/PluginConfig';
-import { Stats4 } from '../../helpers/constants';
+import { Stats4 } from '../../types';
 import extractStats from '../../helpers/extractStats';
 
 const extractedBaseStats = extractStats((baseCompilationStats as unknown) as Stats4);

--- a/src/plugins/restrict/index.test.ts
+++ b/src/plugins/restrict/index.test.ts
@@ -2,15 +2,15 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import RestrictPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { RestrictConfig } from './config';
 import { defaultBasePluginConfig } from '../../config/PluginConfig';
 
-const baseStats = (baseCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
-const headStats = (headCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
+const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
 const restrictConfig: RestrictConfig = {
   showExisting: false,
   chunkFilename: defaultBasePluginConfig.chunkFilename,

--- a/src/plugins/restrict/index.test.ts
+++ b/src/plugins/restrict/index.test.ts
@@ -8,10 +8,10 @@ import headCompilationStats from '../../../test/fixtures/head-compilation-stats.
 import { RestrictConfig } from './config';
 import { defaultBasePluginConfig } from '../../config/PluginConfig';
 import { Stats4 } from '../../types';
-import extractStats from '../../helpers/extractStats';
+import normalizeStats from '../../helpers/normalizeStats';
 
-const extractedBaseStats = extractStats((baseCompilationStats as unknown) as Stats4);
-const extractedHeadStats = extractStats((headCompilationStats as unknown) as Stats4);
+const normalizedBaseStats = normalizeStats((baseCompilationStats as unknown) as Stats4);
+const normalizedHeadStats = normalizeStats((headCompilationStats as unknown) as Stats4);
 const restrictConfig: RestrictConfig = {
   showExisting: false,
   chunkFilename: defaultBasePluginConfig.chunkFilename,
@@ -31,8 +31,8 @@ describe('RestrictPlugin', () => {
   describe('only new restrictions', () => {
     beforeEach(() => {
       restrictPlugin = new RestrictPlugin({
-        baseCompilationStats: extractedBaseStats,
-        headCompilationStats: extractedHeadStats,
+        baseCompilationStats: normalizedBaseStats,
+        headCompilationStats: normalizedHeadStats,
         config: {
           ...restrictConfig,
           showExisting: false,
@@ -66,8 +66,8 @@ describe('RestrictPlugin', () => {
   describe('existing restrictions', () => {
     beforeEach(() => {
       restrictPlugin = new RestrictPlugin({
-        baseCompilationStats: extractedBaseStats,
-        headCompilationStats: extractedHeadStats,
+        baseCompilationStats: normalizedBaseStats,
+        headCompilationStats: normalizedHeadStats,
         config: {
           ...restrictConfig,
           showExisting: true,

--- a/src/plugins/restrict/restrict.test.ts
+++ b/src/plugins/restrict/restrict.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license information.
  */
 import { defaultBasePluginConfig } from '../../config/PluginConfig';
-import { Stats } from '../../helpers/constants';
+import { Stats } from '../../types';
 import extractStats from '../../helpers/extractStats';
 import restrict, { RestrictedModule } from './restrict';
 

--- a/src/plugins/restrict/restrict.test.ts
+++ b/src/plugins/restrict/restrict.test.ts
@@ -4,10 +4,10 @@
  */
 import { defaultBasePluginConfig } from '../../config/PluginConfig';
 import { Stats } from '../../types';
-import extractStats from '../../helpers/extractStats';
+import normalizeStats from '../../helpers/normalizeStats';
 import restrict, { RestrictedModule } from './restrict';
 
-const extractedStats = extractStats({
+const normalizedStats = normalizeStats({
   assets: [
     {
       name: 'file-1-hash.js',
@@ -64,7 +64,7 @@ const extractedStats = extractStats({
 describe('restrict', () => {
   it('returns the expected restricted files', () => {
     expect(
-      restrict(extractedStats, defaultBasePluginConfig.chunkFilename, [
+      restrict(normalizedStats, defaultBasePluginConfig.chunkFilename, [
         { search: 'lodash.omitby', responseType: 'error', message: 'no lodash.omitby' },
       ])
     ).toEqual<RestrictedModule[]>([
@@ -83,7 +83,7 @@ describe('restrict', () => {
 
   it('returns the expected restrict files when using regexp', () => {
     expect(
-      restrict(extractedStats, defaultBasePluginConfig.chunkFilename, [
+      restrict(normalizedStats, defaultBasePluginConfig.chunkFilename, [
         { search: 'lodash.+', responseType: 'error', message: 'no lodash components' },
       ])
     ).toEqual<RestrictedModule[]>([
@@ -113,8 +113,8 @@ describe('restrict', () => {
   it('returns unique results (for multi compile)', () => {
     expect(
       restrict(
-        extractStats({
-          children: [extractedStats.original, extractedStats.original],
+        normalizeStats({
+          children: [normalizedStats.original, normalizedStats.original],
         } as Stats),
         defaultBasePluginConfig.chunkFilename,
         [{ search: 'lodash.omitby', responseType: 'error', message: 'no lodash.omitby' }]

--- a/src/plugins/restrict/restrict.test.ts
+++ b/src/plugins/restrict/restrict.test.ts
@@ -2,11 +2,11 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import { defaultBasePluginConfig } from '../../config/PluginConfig';
 import restrict, { RestrictedModule } from './restrict';
 
-const stats: webpack.Stats.ToJsonOutput = {
+const stats: webpack4.Stats.ToJsonOutput = {
   _showErrors: false,
   _showWarnings: false,
   errors: [],
@@ -39,7 +39,7 @@ const stats: webpack.Stats.ToJsonOutput = {
         },
       ],
       chunks: [1, 2],
-    } as unknown) as webpack.Stats.FnModules,
+    } as unknown) as webpack4.Stats.FnModules,
     ({
       name: './node_modules/lodash.omitby/index.js',
       issuerPath: [
@@ -51,7 +51,7 @@ const stats: webpack.Stats.ToJsonOutput = {
         },
       ],
       chunks: [2],
-    } as unknown) as webpack.Stats.FnModules,
+    } as unknown) as webpack4.Stats.FnModules,
     ({
       name: './node_modules/not-restricted/index.js',
       issuerPath: [
@@ -60,7 +60,7 @@ const stats: webpack.Stats.ToJsonOutput = {
         },
       ],
       chunks: [1],
-    } as unknown) as webpack.Stats.FnModules,
+    } as unknown) as webpack4.Stats.FnModules,
   ],
 };
 

--- a/src/plugins/restrict/restrict.test.ts
+++ b/src/plugins/restrict/restrict.test.ts
@@ -4,9 +4,10 @@
  */
 import webpack4 from 'webpack4';
 import { defaultBasePluginConfig } from '../../config/PluginConfig';
+import { Stats4 } from '../../helpers/constants';
 import restrict, { RestrictedModule } from './restrict';
 
-const stats: webpack4.Stats.ToJsonOutput = {
+const stats: Stats4 = {
   _showErrors: false,
   _showWarnings: false,
   errors: [],

--- a/src/plugins/restrict/restrict.ts
+++ b/src/plugins/restrict/restrict.ts
@@ -5,9 +5,8 @@
 
 import { isEqual } from 'lodash';
 import { Restriction } from './config';
-import { ExtractedStats } from '../../helpers/extractStats';
 import getNameFromAsset from '../../helpers/getNameFromAsset';
-import { Asset, Module, Stats } from '../../types';
+import { Asset, NormalizedStats, Module, Stats } from '../../types';
 
 const FILENAME_EXTENSIONS = /\.(js|mjs)$/iu;
 
@@ -19,11 +18,11 @@ export interface RestrictedModule {
 }
 
 const restrict = (
-  extractedStats: ExtractedStats,
+  normalizedStats: NormalizedStats,
   chunkFilename: string,
   restrictions: Restriction[]
 ): RestrictedModule[] => {
-  const restrictedModules = (extractedStats.stats as Stats[]).reduce((result, stats) => {
+  const restrictedModules = (normalizedStats.stats as Stats[]).reduce((result, stats) => {
     const module = (stats.modules as Module[])
       .map(({ name, chunks, issuerPath }) => {
         const restriction = restrictions.find(({ search }) => new RegExp(search).test(name));

--- a/src/plugins/restrict/restrict.ts
+++ b/src/plugins/restrict/restrict.ts
@@ -7,7 +7,7 @@ import { isEqual } from 'lodash';
 import { Restriction } from './config';
 import { ExtractedStats } from '../../helpers/extractStats';
 import getNameFromAsset from '../../helpers/getNameFromAsset';
-import { Asset, Module, Stats } from '../../helpers/constants';
+import { Asset, Module, Stats } from '../../types';
 
 const FILENAME_EXTENSIONS = /\.(js|mjs)$/iu;
 

--- a/src/plugins/restrict/restrict.ts
+++ b/src/plugins/restrict/restrict.ts
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import { isEqual } from 'lodash';
 import { Restriction } from './config';
 import extractStats from '../../helpers/extractStats';
@@ -20,7 +20,7 @@ export interface RestrictedModule {
 }
 
 const restrict = (
-  compilationStats: webpack.Stats.ToJsonOutput,
+  compilationStats: webpack4.Stats.ToJsonOutput,
   chunkFilename: string,
   restrictions: Restriction[]
 ): RestrictedModule[] => {

--- a/src/plugins/size-changes/index.test.ts
+++ b/src/plugins/size-changes/index.test.ts
@@ -9,6 +9,7 @@ import { Budget, defaultSizeChangesConfig } from './config';
 import { SizeChange } from './SizeChange';
 import { TableType } from './table';
 import { Stats4 } from '../../helpers/constants';
+import extractStats from '../../helpers/extractStats';
 
 jest.mock('./table', () => {
   const actualTable = jest.requireActual('./table');
@@ -29,8 +30,8 @@ describe('SizeChangesPlugin', () => {
   describe('default configuration', () => {
     beforeEach(() => {
       sizeChanges = new SizeChangesPlugin({
-        baseCompilationStats: baseStats,
-        headCompilationStats: headStats,
+        baseCompilationStats: extractStats(baseStats),
+        headCompilationStats: extractStats(headStats),
         config: defaultSizeChangesConfig,
       });
     });
@@ -67,8 +68,8 @@ html table
   describe('no changes', () => {
     beforeEach(() => {
       sizeChanges = new SizeChangesPlugin({
-        baseCompilationStats: baseStats,
-        headCompilationStats: baseStats,
+        baseCompilationStats: extractStats(baseStats),
+        headCompilationStats: extractStats(baseStats),
         config: defaultSizeChangesConfig,
       });
     });
@@ -105,8 +106,8 @@ html table
   describe('config.hideMinorChanges', () => {
     beforeEach(() => {
       sizeChanges = new SizeChangesPlugin({
-        baseCompilationStats: baseStats,
-        headCompilationStats: headStats,
+        baseCompilationStats: extractStats(baseStats),
+        headCompilationStats: extractStats(headStats),
         config: { ...defaultSizeChangesConfig, hideMinorChanges: true },
       });
     });
@@ -137,8 +138,8 @@ html table
 
     beforeEach(() => {
       sizeChanges = new SizeChangesPlugin({
-        baseCompilationStats: baseStats,
-        headCompilationStats: headStats,
+        baseCompilationStats: extractStats(baseStats),
+        headCompilationStats: extractStats(headStats),
         config: { ...defaultSizeChangesConfig, hideMinorChanges: true, budget },
       });
     });

--- a/src/plugins/size-changes/index.test.ts
+++ b/src/plugins/size-changes/index.test.ts
@@ -8,7 +8,7 @@ import headCompilationStats from '../../../test/fixtures/head-compilation-stats.
 import { Budget, defaultSizeChangesConfig } from './config';
 import { SizeChange } from './SizeChange';
 import { TableType } from './table';
-import { Stats4 } from '../../helpers/constants';
+import { Stats4 } from '../../types';
 import extractStats from '../../helpers/extractStats';
 
 jest.mock('./table', () => {

--- a/src/plugins/size-changes/index.test.ts
+++ b/src/plugins/size-changes/index.test.ts
@@ -2,13 +2,13 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack4 from 'webpack4';
 import SizeChangesPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { Budget, defaultSizeChangesConfig } from './config';
 import { SizeChange } from './SizeChange';
 import { TableType } from './table';
+import { Stats4 } from '../../helpers/constants';
 
 jest.mock('./table', () => {
   const actualTable = jest.requireActual('./table');
@@ -20,8 +20,8 @@ jest.mock('./table', () => {
   };
 });
 
-const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
-const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const baseStats = (baseCompilationStats as unknown) as Stats4;
+const headStats = (headCompilationStats as unknown) as Stats4;
 
 describe('SizeChangesPlugin', () => {
   let sizeChanges: SizeChangesPlugin;

--- a/src/plugins/size-changes/index.test.ts
+++ b/src/plugins/size-changes/index.test.ts
@@ -9,7 +9,7 @@ import { Budget, defaultSizeChangesConfig } from './config';
 import { SizeChange } from './SizeChange';
 import { TableType } from './table';
 import { Stats4 } from '../../types';
-import extractStats from '../../helpers/extractStats';
+import normalizeStats from '../../helpers/normalizeStats';
 
 jest.mock('./table', () => {
   const actualTable = jest.requireActual('./table');
@@ -30,8 +30,8 @@ describe('SizeChangesPlugin', () => {
   describe('default configuration', () => {
     beforeEach(() => {
       sizeChanges = new SizeChangesPlugin({
-        baseCompilationStats: extractStats(baseStats),
-        headCompilationStats: extractStats(headStats),
+        baseCompilationStats: normalizeStats(baseStats),
+        headCompilationStats: normalizeStats(headStats),
         config: defaultSizeChangesConfig,
       });
     });
@@ -68,8 +68,8 @@ html table
   describe('no changes', () => {
     beforeEach(() => {
       sizeChanges = new SizeChangesPlugin({
-        baseCompilationStats: extractStats(baseStats),
-        headCompilationStats: extractStats(baseStats),
+        baseCompilationStats: normalizeStats(baseStats),
+        headCompilationStats: normalizeStats(baseStats),
         config: defaultSizeChangesConfig,
       });
     });
@@ -106,8 +106,8 @@ html table
   describe('config.hideMinorChanges', () => {
     beforeEach(() => {
       sizeChanges = new SizeChangesPlugin({
-        baseCompilationStats: extractStats(baseStats),
-        headCompilationStats: extractStats(headStats),
+        baseCompilationStats: normalizeStats(baseStats),
+        headCompilationStats: normalizeStats(headStats),
         config: { ...defaultSizeChangesConfig, hideMinorChanges: true },
       });
     });
@@ -138,8 +138,8 @@ html table
 
     beforeEach(() => {
       sizeChanges = new SizeChangesPlugin({
-        baseCompilationStats: extractStats(baseStats),
-        headCompilationStats: extractStats(headStats),
+        baseCompilationStats: normalizeStats(baseStats),
+        headCompilationStats: normalizeStats(headStats),
         config: { ...defaultSizeChangesConfig, hideMinorChanges: true, budget },
       });
     });

--- a/src/plugins/size-changes/index.test.ts
+++ b/src/plugins/size-changes/index.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import SizeChangesPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
@@ -20,8 +20,8 @@ jest.mock('./table', () => {
   };
 });
 
-const baseStats = (baseCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
-const headStats = (headCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
+const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
 
 describe('SizeChangesPlugin', () => {
   let sizeChanges: SizeChangesPlugin;

--- a/src/plugins/trace-changes/index.test.ts
+++ b/src/plugins/trace-changes/index.test.ts
@@ -6,7 +6,7 @@ import TraceChangesPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { Stats4 } from '../../types';
-import extractStats from '../../helpers/extractStats';
+import normalizeStats from '../../helpers/normalizeStats';
 
 const baseStats = (baseCompilationStats as unknown) as Stats4;
 const headStats = (headCompilationStats as unknown) as Stats4;
@@ -17,8 +17,8 @@ describe('TraceChangesPlugin', () => {
   describe('changes available', () => {
     beforeEach(() => {
       traceChanges = new TraceChangesPlugin({
-        baseCompilationStats: extractStats(baseStats),
-        headCompilationStats: extractStats(headStats),
+        baseCompilationStats: normalizeStats(baseStats),
+        headCompilationStats: normalizeStats(headStats),
         config: true,
       });
     });
@@ -39,8 +39,8 @@ describe('TraceChangesPlugin', () => {
   describe('no changes available', () => {
     beforeEach(() => {
       traceChanges = new TraceChangesPlugin({
-        baseCompilationStats: extractStats(baseStats),
-        headCompilationStats: extractStats(baseStats),
+        baseCompilationStats: normalizeStats(baseStats),
+        headCompilationStats: normalizeStats(baseStats),
         config: true,
       });
     });

--- a/src/plugins/trace-changes/index.test.ts
+++ b/src/plugins/trace-changes/index.test.ts
@@ -6,6 +6,7 @@ import TraceChangesPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 import { Stats4 } from '../../helpers/constants';
+import extractStats from '../../helpers/extractStats';
 
 const baseStats = (baseCompilationStats as unknown) as Stats4;
 const headStats = (headCompilationStats as unknown) as Stats4;
@@ -16,8 +17,8 @@ describe('TraceChangesPlugin', () => {
   describe('changes available', () => {
     beforeEach(() => {
       traceChanges = new TraceChangesPlugin({
-        baseCompilationStats: baseStats,
-        headCompilationStats: headStats,
+        baseCompilationStats: extractStats(baseStats),
+        headCompilationStats: extractStats(headStats),
         config: true,
       });
     });
@@ -38,8 +39,8 @@ describe('TraceChangesPlugin', () => {
   describe('no changes available', () => {
     beforeEach(() => {
       traceChanges = new TraceChangesPlugin({
-        baseCompilationStats: baseStats,
-        headCompilationStats: baseStats,
+        baseCompilationStats: extractStats(baseStats),
+        headCompilationStats: extractStats(baseStats),
         config: true,
       });
     });

--- a/src/plugins/trace-changes/index.test.ts
+++ b/src/plugins/trace-changes/index.test.ts
@@ -5,7 +5,7 @@
 import TraceChangesPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
-import { Stats4 } from '../../helpers/constants';
+import { Stats4 } from '../../types';
 import extractStats from '../../helpers/extractStats';
 
 const baseStats = (baseCompilationStats as unknown) as Stats4;

--- a/src/plugins/trace-changes/index.test.ts
+++ b/src/plugins/trace-changes/index.test.ts
@@ -2,13 +2,13 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack from 'webpack';
+import webpack4 from 'webpack4';
 import TraceChangesPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
 
-const baseStats = (baseCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
-const headStats = (headCompilationStats as unknown) as webpack.Stats.ToJsonOutput;
+const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
 
 describe('TraceChangesPlugin', () => {
   let traceChanges: TraceChangesPlugin;

--- a/src/plugins/trace-changes/index.test.ts
+++ b/src/plugins/trace-changes/index.test.ts
@@ -2,13 +2,13 @@
  * Copyright (c) Trainline Limited, 2020. All rights reserved.
  * See LICENSE.md in the project root for license information.
  */
-import webpack4 from 'webpack4';
 import TraceChangesPlugin from './index';
 import baseCompilationStats from '../../../test/fixtures/base-compilation-stats.json';
 import headCompilationStats from '../../../test/fixtures/head-compilation-stats.json';
+import { Stats4 } from '../../helpers/constants';
 
-const baseStats = (baseCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
-const headStats = (headCompilationStats as unknown) as webpack4.Stats.ToJsonOutput;
+const baseStats = (baseCompilationStats as unknown) as Stats4;
+const headStats = (headCompilationStats as unknown) as Stats4;
 
 describe('TraceChangesPlugin', () => {
   let traceChanges: TraceChangesPlugin;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,3 +17,23 @@ export type Asset = Asset5 | Asset4;
 export type Module5 = Stats5['modules'][0];
 export type Module4 = Stats4['modules'][0];
 export type Module = Module5 | Module4;
+
+export type NormalizedStats = NormalizedStats5 | NormalizedStats4;
+
+type BaseNormalizedStats = {
+  majorVersion: 4 | 5;
+  stats: Stats[];
+  original: Stats;
+};
+
+export type NormalizedStats5 = BaseNormalizedStats & {
+  majorVersion: 5;
+  stats: Stats5[];
+  original: Stats;
+};
+
+export type NormalizedStats4 = BaseNormalizedStats & {
+  majorVersion: 4;
+  stats: Stats4[];
+  original: Stats;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Trainline Limited, 2020. All rights reserved.
+ * See LICENSE.md in the project root for license information.
+ */
+
+/* eslint-disable import/no-extraneous-dependencies */
+import webpack from 'webpack';
+import webpack4 from 'webpack4';
+/* eslint-enable import/no-extraneous-dependencies */
+
+export type Stats5 = ReturnType<webpack.Stats['toJson']>;
+export type Stats4 = webpack4.Stats.ToJsonOutput;
+export type Stats = Stats5 | Stats4;
+export type Asset5 = Stats5['assets'][0];
+export type Asset4 = Stats4['assets'][0];
+export type Asset = Asset5 | Asset4;
+export type Module5 = Stats5['modules'][0];
+export type Module4 = Stats4['modules'][0];
+export type Module = Module5 | Module4;

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,10 +836,10 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^0.0.46":
-  version "0.0.46"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
-  integrity sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
+"@types/estree@*", "@types/estree@^0.0.47":
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
+  integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
@@ -1425,10 +1425,10 @@ acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.0.4:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.4.tgz#7a3ae4191466a6984eee0fe3407a4f3aa9db8354"
-  integrity sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==
+acorn@^8.2.1:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.2.2.tgz#c4574e4fea298d6e6ed4b85ab844b06dd59f26d6"
+  integrity sha512-VrMS8kxT0e7J1EX0p6rI/E0FbfOVcvBpbIqHThFv+f8YrZIlMfVotYcXKVPmTvPW8sW5miJzfUFrrvthUZg8VQ==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -3270,10 +3270,10 @@ enhanced-resolve@^4.3.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz#525c5d856680fbd5052de453ac83e32049958b5c"
-  integrity sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==
+enhanced-resolve@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.0.tgz#d9deae58f9d3773b6a111a5a46831da5be5c9ac0"
+  integrity sha512-Sl3KRpJA8OpprrtaIswVki3cWPiPKxXuFxJXBp+zNb6s6VwNWwFRUdtmzd2ReUut8n+sCPx7QCtQ7w5wfJhSgQ==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -3334,10 +3334,10 @@ es-abstract@^1.18.0-next.1:
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
-es-module-lexer@^0.3.26:
-  version "0.3.26"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.3.26.tgz#7b507044e97d5b03b01d4392c74ffeb9c177a83b"
-  integrity sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==
+es-module-lexer@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.4.1.tgz#dda8c6a14d8f340a24e34331e0fab0cb50438e0e"
+  integrity sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -9062,21 +9062,21 @@ webpack-sources@^2.1.1:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-webpack@^5.21.0:
-  version "5.21.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.21.0.tgz#0dac2d97a2b274f2bd14c043d60cba11e0eb2198"
-  integrity sha512-DoFw0eAPbh2DXyBn0nP5lMnytPXlkLsdXOpBQyibf+1OCnThxUVPzMbth/+JS97HN0mfl7OhLmEKLw+kg0jmkg==
+webpack@^5.36.2:
+  version "5.36.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.36.2.tgz#6ef1fb2453ad52faa61e78d486d353d07cca8a0f"
+  integrity sha512-XJumVnnGoH2dV+Pk1VwgY4YT6AiMKpVoudUFCNOXMIVrEKPUgEwdIfWPjIuGLESAiS8EdIHX5+TiJz/5JccmRg==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
-    "@types/estree" "^0.0.46"
+    "@types/estree" "^0.0.47"
     "@webassemblyjs/ast" "1.11.0"
     "@webassemblyjs/wasm-edit" "1.11.0"
     "@webassemblyjs/wasm-parser" "1.11.0"
-    acorn "^8.0.4"
+    acorn "^8.2.1"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.7.0"
-    es-module-lexer "^0.3.26"
+    enhanced-resolve "^5.8.0"
+    es-module-lexer "^0.4.0"
     eslint-scope "^5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,10 +836,10 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^0.0.45":
-  version "0.0.45"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
-  integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
+"@types/estree@*", "@types/estree@^0.0.46":
+  version "0.0.46"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
+  integrity sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
@@ -1101,6 +1101,14 @@
     "@typescript-eslint/types" "4.7.0"
     eslint-visitor-keys "^2.0.0"
 
+"@webassemblyjs/ast@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.0.tgz#a5aa679efdc9e51707a4207139da57920555961f"
+  integrity sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -1110,15 +1118,30 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
 
+"@webassemblyjs/floating-point-hex-parser@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz#34d62052f453cd43101d72eab4966a022587947c"
+  integrity sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==
+
 "@webassemblyjs/floating-point-hex-parser@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
   integrity sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==
 
+"@webassemblyjs/helper-api-error@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz#aaea8fb3b923f4aaa9b512ff541b013ffb68d2d4"
+  integrity sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==
+
 "@webassemblyjs/helper-api-error@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
   integrity sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==
+
+"@webassemblyjs/helper-buffer@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz#d026c25d175e388a7dbda9694e91e743cbe9b642"
+  integrity sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==
 
 "@webassemblyjs/helper-buffer@1.9.0":
   version "1.9.0"
@@ -1144,10 +1167,34 @@
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
 
+"@webassemblyjs/helper-numbers@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.0.tgz#7ab04172d54e312cc6ea4286d7d9fa27c88cd4f9"
+  integrity sha512-DhRQKelIj01s5IgdsOJMKLppI+4zpmcMQ3XboFPLwCpSNH6Hqo1ritgHgD0nqHeSYqofA6aBN/NmXuGjM1jEfQ==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.0"
+    "@webassemblyjs/helper-api-error" "1.11.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz#85fdcda4129902fe86f81abf7e7236953ec5a4e1"
+  integrity sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==
+
 "@webassemblyjs/helper-wasm-bytecode@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790"
   integrity sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==
+
+"@webassemblyjs/helper-wasm-section@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.0.tgz#9ce2cc89300262509c801b4af113d1ca25c1a75b"
+  integrity sha512-3Eb88hcbfY/FCukrg6i3EH8H2UsD7x8Vy47iVJrP967A9JGqgBVL9aH71SETPx1JrGsOUVLo0c7vMCN22ytJew==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
 
 "@webassemblyjs/helper-wasm-section@1.9.0":
   version "1.9.0"
@@ -1159,12 +1206,26 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
 
+"@webassemblyjs/ieee754@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.0.tgz#46975d583f9828f5d094ac210e219441c4e6f5cf"
+  integrity sha512-KXzOqpcYQwAfeQ6WbF6HXo+0udBNmw0iXDmEK5sFlmQdmND+tr773Ti8/5T/M6Tl/413ArSJErATd8In3B+WBA==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
 "@webassemblyjs/ieee754@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
   integrity sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.0.tgz#f7353de1df38aa201cba9fb88b43f41f75ff403b"
+  integrity sha512-aqbsHa1mSQAbeeNcl38un6qVY++hh8OpCOzxhixSYgbRfNWcxJNJQwe2rezK9XEcssJbbWIkblaJRwGMS9zp+g==
+  dependencies:
+    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/leb128@1.9.0":
   version "1.9.0"
@@ -1173,10 +1234,29 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/utf8@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.0.tgz#86e48f959cf49e0e5091f069a709b862f5a2cadf"
+  integrity sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==
+
 "@webassemblyjs/utf8@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab"
   integrity sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==
+
+"@webassemblyjs/wasm-edit@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.0.tgz#ee4a5c9f677046a210542ae63897094c2027cb78"
+  integrity sha512-JHQ0damXy0G6J9ucyKVXO2j08JVJ2ntkdJlq1UTiUrIgfGMmA7Ik5VdC/L8hBK46kVJgujkBIoMtT8yVr+yVOQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/helper-wasm-section" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
+    "@webassemblyjs/wasm-opt" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+    "@webassemblyjs/wast-printer" "1.11.0"
 
 "@webassemblyjs/wasm-edit@1.9.0":
   version "1.9.0"
@@ -1192,6 +1272,17 @@
     "@webassemblyjs/wasm-parser" "1.9.0"
     "@webassemblyjs/wast-printer" "1.9.0"
 
+"@webassemblyjs/wasm-gen@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.0.tgz#3cdb35e70082d42a35166988dda64f24ceb97abe"
+  integrity sha512-BEUv1aj0WptCZ9kIS30th5ILASUnAPEvE3tVMTrItnZRT9tXCLW2LEXT8ezLw59rqPP9klh9LPmpU+WmRQmCPQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/ieee754" "1.11.0"
+    "@webassemblyjs/leb128" "1.11.0"
+    "@webassemblyjs/utf8" "1.11.0"
+
 "@webassemblyjs/wasm-gen@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
@@ -1203,6 +1294,16 @@
     "@webassemblyjs/leb128" "1.9.0"
     "@webassemblyjs/utf8" "1.9.0"
 
+"@webassemblyjs/wasm-opt@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.0.tgz#1638ae188137f4bb031f568a413cd24d32f92978"
+  integrity sha512-tHUSP5F4ywyh3hZ0+fDQuWxKx3mJiPeFufg+9gwTpYp324mPCQgnuVKwzLTZVqj0duRDovnPaZqDwoyhIO8kYg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+
 "@webassemblyjs/wasm-opt@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61"
@@ -1212,6 +1313,18 @@
     "@webassemblyjs/helper-buffer" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
+
+"@webassemblyjs/wasm-parser@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.0.tgz#3e680b8830d5b13d1ec86cc42f38f3d4a7700754"
+  integrity sha512-6L285Sgu9gphrcpDXINvm0M9BskznnzJTE7gYkjDbxET28shDqp27wpruyx3C2S/dvEwiigBwLA1cz7lNUi0kw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-api-error" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/ieee754" "1.11.0"
+    "@webassemblyjs/leb128" "1.11.0"
+    "@webassemblyjs/utf8" "1.11.0"
 
 "@webassemblyjs/wasm-parser@1.9.0":
   version "1.9.0"
@@ -1235,6 +1348,14 @@
     "@webassemblyjs/helper-api-error" "1.9.0"
     "@webassemblyjs/helper-code-frame" "1.9.0"
     "@webassemblyjs/helper-fsm" "1.9.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/wast-printer@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.0.tgz#680d1f6a5365d6d401974a8e949e05474e1fab7e"
+  integrity sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
     "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/wast-printer@1.9.0":
@@ -3149,13 +3270,13 @@ enhanced-resolve@^4.3.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.3.1:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.4.0.tgz#a8bcf23b00affac9455cf71efd80844f4054f4dc"
-  integrity sha512-ZmqfWURB2lConOBM1JdCVfPyMRv5RdKWktLXO6123p97ovVm2CLBgw9t5MBj3jJWA6eHyOeIws9iJQoGFR4euQ==
+enhanced-resolve@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz#525c5d856680fbd5052de453ac83e32049958b5c"
+  integrity sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==
   dependencies:
     graceful-fs "^4.2.4"
-    tapable "^2.0.0"
+    tapable "^2.2.0"
 
 enquirer@^2.3.5:
   version "2.3.6"
@@ -3212,6 +3333,11 @@ es-abstract@^1.18.0-next.1:
     object.assign "^4.1.1"
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
+
+es-module-lexer@^0.3.26:
+  version "0.3.26"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.3.26.tgz#7b507044e97d5b03b01d4392c74ffeb9c177a83b"
+  integrity sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -5352,7 +5478,7 @@ jest-watcher@^26.6.2:
     jest-util "^26.6.2"
     string-length "^4.0.1"
 
-jest-worker@^26.6.1, jest-worker@^26.6.2:
+jest-worker@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
   integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
@@ -5689,10 +5815,10 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-runner@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.1.0.tgz#f70bc0c29edbabdf2043e7ee73ccc3fe1c96b42d"
-  integrity sha512-oR4lB4WvwFoC70ocraKhn5nkKSs23t57h9udUgw8o0iH8hMXeEoRuUgfcvgUwAJ1ZpRqBvcou4N2SMvM1DwMrA==
+loader-runner@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
+  integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
 loader-utils@^1.2.3:
   version "1.4.0"
@@ -6617,12 +6743,12 @@ p-limit@^2.0.0, p-limit@^2.1.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
-  integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==
+p-limit@^3.0.2, p-limit@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
-    p-try "^2.0.0"
+    yocto-queue "^0.1.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -8243,10 +8369,10 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tapable@^2.0.0, tapable@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.1.1.tgz#b01cc1902d42a7bb30514e320ce21c456f72fd3f"
-  integrity sha512-Wib1S8m2wdpLbmQz0RBEVosIyvb/ykfKXf3ZIDqvWoMg/zTNm6G/tDSuUM61J1kNCDXWJrLHGSFeMhAG+gAGpQ==
+tapable@^2.1.1, tapable@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
+  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
 
 temp-dir@^1.0.0:
   version "1.0.0"
@@ -8300,17 +8426,17 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser-webpack-plugin@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz#ec60542db2421f45735c719d2e17dabfbb2e3e42"
-  integrity sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==
+terser-webpack-plugin@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.1.1.tgz#7effadee06f7ecfa093dbbd3e9ab23f5f3ed8673"
+  integrity sha512-5XNNXZiR8YO6X6KhSGXfY0QrGrCRlSwAEjIIrlRQR4W8nP69TaJUlh3bkuac6zzgspiGPfKEHcY295MMVExl5Q==
   dependencies:
-    jest-worker "^26.6.1"
-    p-limit "^3.0.2"
+    jest-worker "^26.6.2"
+    p-limit "^3.1.0"
     schema-utils "^3.0.0"
     serialize-javascript "^5.0.1"
     source-map "^0.6.1"
-    terser "^5.3.8"
+    terser "^5.5.1"
 
 terser@^4.1.2:
   version "4.8.0"
@@ -8321,7 +8447,7 @@ terser@^4.1.2:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.3.8:
+terser@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.5.1.tgz#540caa25139d6f496fdea056e414284886fb2289"
   integrity sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==
@@ -8936,33 +9062,32 @@ webpack-sources@^2.1.1:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-webpack@^5.9.0:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.9.0.tgz#af2e9cf9d6c7867cdcf214ea3bb5eb77aece6895"
-  integrity sha512-YnnqIV/uAS5ZrNpctSv378qV7HmbJ74DL+XfvMxzbX1bV9e7eeT6eEWU4wuUw33CNr/HspBh7R/xQlVjTEyAeA==
+webpack@^5.21.0:
+  version "5.21.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.21.0.tgz#0dac2d97a2b274f2bd14c043d60cba11e0eb2198"
+  integrity sha512-DoFw0eAPbh2DXyBn0nP5lMnytPXlkLsdXOpBQyibf+1OCnThxUVPzMbth/+JS97HN0mfl7OhLmEKLw+kg0jmkg==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
-    "@types/estree" "^0.0.45"
-    "@webassemblyjs/ast" "1.9.0"
-    "@webassemblyjs/helper-module-context" "1.9.0"
-    "@webassemblyjs/wasm-edit" "1.9.0"
-    "@webassemblyjs/wasm-parser" "1.9.0"
+    "@types/estree" "^0.0.46"
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/wasm-edit" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
     acorn "^8.0.4"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.3.1"
+    enhanced-resolve "^5.7.0"
+    es-module-lexer "^0.3.26"
     eslint-scope "^5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.2.4"
     json-parse-better-errors "^1.0.2"
-    loader-runner "^4.1.0"
+    loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
-    pkg-dir "^4.2.0"
     schema-utils "^3.0.0"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.0.3"
+    terser-webpack-plugin "^5.1.1"
     watchpack "^2.0.0"
     webpack-sources "^2.1.1"
 
@@ -9173,3 +9298,8 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -815,10 +815,31 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
+"@types/eslint-scope@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"
+  integrity sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/eslint@*":
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.6.tgz#5e9aff555a975596c03a98b59ecd103decc70c3c"
+  integrity sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*", "@types/estree@^0.0.45":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
+  integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
@@ -859,7 +880,7 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/json-schema@^7.0.3":
+"@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
@@ -1283,6 +1304,11 @@ acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
+acorn@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.4.tgz#7a3ae4191466a6984eee0fe3407a4f3aa9db8354"
+  integrity sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ==
+
 add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
@@ -1300,12 +1326,12 @@ ajv-errors@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
-ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
+ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1821,6 +1847,17 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+browserslist@^4.14.5:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.15.0.tgz#3d48bbca6a3f378e86102ffd017d9a03f122bdb0"
+  integrity sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==
+  dependencies:
+    caniuse-lite "^1.0.30001164"
+    colorette "^1.2.1"
+    electron-to-chromium "^1.3.612"
+    escalade "^3.1.1"
+    node-releases "^1.1.67"
+
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
@@ -2004,6 +2041,11 @@ camelcase@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+
+caniuse-lite@^1.0.30001164:
+  version "1.0.30001164"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz#5bbfd64ca605d43132f13cc7fdabb17c3036bfdc"
+  integrity sha512-G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -2222,6 +2264,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colorette@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
+  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
 colors@^1.1.2:
   version "1.4.0"
@@ -3043,6 +3090,11 @@ editor@1.0.0:
   resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
   integrity sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=
 
+electron-to-chromium@^1.3.612:
+  version "1.3.614"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.614.tgz#ff359e8d2249e2ce859a4c2bc34c22bd2e2eb0a2"
+  integrity sha512-JMDl46mg4G+n6q/hAJkwy9eMTj5FJjsE+8f/irAGRMLM4yeRVbMuRrdZrbbGGOrGVcZc4vJPjUpEUWNb/fA6hg==
+
 elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
@@ -3096,6 +3148,14 @@ enhanced-resolve@^4.3.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
     tapable "^1.0.0"
+
+enhanced-resolve@^5.3.1:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.4.0.tgz#a8bcf23b00affac9455cf71efd80844f4054f4dc"
+  integrity sha512-ZmqfWURB2lConOBM1JdCVfPyMRv5RdKWktLXO6123p97ovVm2CLBgw9t5MBj3jJWA6eHyOeIws9iJQoGFR4euQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.0.0"
 
 enquirer@^2.3.5:
   version "2.3.6"
@@ -3173,6 +3233,11 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-goat@^2.0.0:
   version "2.1.1"
@@ -3430,7 +3495,7 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-events@^3.0.0:
+events@^3.0.0, events@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
   integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
@@ -4046,6 +4111,11 @@ glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
+
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@7.1.4:
   version "7.1.4"
@@ -5282,7 +5352,7 @@ jest-watcher@^26.6.2:
     jest-util "^26.6.2"
     string-length "^4.0.1"
 
-jest-worker@^26.6.2:
+jest-worker@^26.6.1, jest-worker@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
   integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
@@ -5618,6 +5688,11 @@ loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
+
+loader-runner@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.1.0.tgz#f70bc0c29edbabdf2043e7ee73ccc3fe1c96b42d"
+  integrity sha512-oR4lB4WvwFoC70ocraKhn5nkKSs23t57h9udUgw8o0iH8hMXeEoRuUgfcvgUwAJ1ZpRqBvcou4N2SMvM1DwMrA==
 
 loader-utils@^1.2.3:
   version "1.4.0"
@@ -6018,7 +6093,7 @@ mime-db@1.44.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
-mime-types@2.1.27, mime-types@^2.1.12, mime-types@~2.1.19:
+mime-types@2.1.27, mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
@@ -6189,7 +6264,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
+neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -6259,6 +6334,11 @@ node-notifier@^8.0.0:
     shellwords "^0.1.1"
     uuid "^8.3.0"
     which "^2.0.2"
+
+node-releases@^1.1.67:
+  version "1.1.67"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
+  integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
 
 normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -7605,6 +7685,15 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+schema-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.0.0.tgz#67502f6aa2b66a2d4032b4279a2944978a0913ef"
+  integrity sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
+  dependencies:
+    "@types/json-schema" "^7.0.6"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -7648,6 +7737,13 @@ serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
 
@@ -7771,7 +7867,7 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-source-list-map@^2.0.0:
+source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -7787,7 +7883,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -7810,7 +7906,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
+source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -8147,6 +8243,11 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tapable@^2.0.0, tapable@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.1.1.tgz#b01cc1902d42a7bb30514e320ce21c456f72fd3f"
+  integrity sha512-Wib1S8m2wdpLbmQz0RBEVosIyvb/ykfKXf3ZIDqvWoMg/zTNm6G/tDSuUM61J1kNCDXWJrLHGSFeMhAG+gAGpQ==
+
 temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
@@ -8199,6 +8300,18 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
+terser-webpack-plugin@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.0.3.tgz#ec60542db2421f45735c719d2e17dabfbb2e3e42"
+  integrity sha512-zFdGk8Lh9ZJGPxxPE6jwysOlATWB8GMW8HcfGULWA/nPal+3VdATflQvSBSLQJRCmYZnfFJl6vkRTiwJGNgPiQ==
+  dependencies:
+    jest-worker "^26.6.1"
+    p-limit "^3.0.2"
+    schema-utils "^3.0.0"
+    serialize-javascript "^5.0.1"
+    source-map "^0.6.1"
+    terser "^5.3.8"
+
 terser@^4.1.2:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -8207,6 +8320,15 @@ terser@^4.1.2:
     commander "^2.20.0"
     source-map "~0.6.1"
     source-map-support "~0.5.12"
+
+terser@^5.3.8:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.5.1.tgz#540caa25139d6f496fdea056e414284886fb2289"
+  integrity sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -8739,6 +8861,14 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
+watchpack@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.0.1.tgz#2f2192c542c82a3bcde76acd3411470c120426a8"
+  integrity sha512-vO8AKGX22ZRo6PiOFM9dC0re8IcKh8Kd/aH2zeqUc6w4/jBGlTy2P7fTC6ekT0NjVeGjgU2dGC5rNstKkeLEQg==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
@@ -8769,6 +8899,14 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-sources@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
+  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
+
 "webpack4@npm:webpack@^4.44.2":
   version "4.44.2"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.2.tgz#6bfe2b0af055c8b2d1e90ed2cd9363f841266b72"
@@ -8797,6 +8935,36 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
+
+webpack@^5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.9.0.tgz#af2e9cf9d6c7867cdcf214ea3bb5eb77aece6895"
+  integrity sha512-YnnqIV/uAS5ZrNpctSv378qV7HmbJ74DL+XfvMxzbX1bV9e7eeT6eEWU4wuUw33CNr/HspBh7R/xQlVjTEyAeA==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.45"
+    "@webassemblyjs/ast" "1.9.0"
+    "@webassemblyjs/helper-module-context" "1.9.0"
+    "@webassemblyjs/wasm-edit" "1.9.0"
+    "@webassemblyjs/wasm-parser" "1.9.0"
+    acorn "^8.0.4"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.3.1"
+    eslint-scope "^5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.1.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    pkg-dir "^4.2.0"
+    schema-utils "^3.0.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.0.3"
+    watchpack "^2.0.0"
+    webpack-sources "^2.1.1"
 
 whatwg-encoding@^1.0.5:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,7 +949,7 @@
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
-"@types/webpack@^4.41.24":
+"@types/webpack4@npm:@types/webpack@^4.41.24":
   version "4.41.25"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.25.tgz#4d3b5aecc4e44117b376280fbfd2dc36697968c4"
   integrity sha512-cr6kZ+4m9lp86ytQc1jPOJXgINQyz3kLLunZ57jznW+WIAL0JqZbGubQk4GlD42MuQL5JGOABrxdpqqWeovlVQ==
@@ -8769,7 +8769,7 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.44.2:
+"webpack4@npm:webpack@^4.44.2":
   version "4.44.2"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.2.tgz#6bfe2b0af055c8b2d1e90ed2cd9363f841266b72"
   integrity sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==


### PR DESCRIPTION
## Description
This PR adds support for webpack v5 stats files.

Changes to highlight:
- Used npm aliasing to support both webpack v5 and v4 usage within the codebase
- Refactored `extractStats` (and renamed to `normalizeStats`) to tell what the major version is of the stats that is being parsed
- Refactored `normalizeStats` to include both the original format, and the normalised format
- I've moved the logic of `normalizeStats` to be done by the CLI/danger call, meaning data sources return the stats, it gets normalized, then passed to each of the plugins for use
- Updated what tests were necessary to reflect the differences between webpack v4 and v5
- Only the types file references webpack now, everything else should go via that (exception being the `MergeCompilationStatsWebpackPlugin` as it needs the `version` property). This is done so that it is easier to manage the type definitions between v4 and v5

Note to reviewers/mergers:
- Please squash merge this PR, rather than just merging
- I only had 1 copy of DSEO webpack v5 stats, and it was off a PR that I created and got working on my last day with Trainline, so there isn't as an exhaustive amount of tests as I would have liked
-  With TypeScript and the recent merger of https://github.com/webpack/webpack/pull/12228 it does mean that we should be confident enough to assume all is well
- It would still be good for this to be verified against a webpack v5 configured application (which I presently don't really have access to)
- As DSEO used custom stats configuration where we disabled everything by default and only enabled `assets` and `modules`, we may also need to enable [`relatedAssets`](https://webpack.js.org/configuration/stats/#statsrelatedassets) due to the code change done in [`src/helpers/mapChunkNamesExtensionsToSize.test.ts`](https://github.com/trainline/webpack-bundle-delta/pull/14/files#diff-724a1aa99c2e2544c280ee5a468eb999105f7e76a3d7ec3de514df2f466e78b9).
  - If this is the case, we will also need to update [the documentation](https://github.com/trainline/webpack-bundle-delta/blob/master/docs/gather-webpack-stats.md) stating so.

## Motivation and Context
Resolves #4 

## How Has This Been Tested?
Unit tests

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] Any documentation has been updated as required.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.